### PR TITLE
Return server error message if provided

### DIFF
--- a/projects/ngx-web-framework/moryx-snackbar/src/moryx-snackbar/moryx-snackbar.service.ts
+++ b/projects/ngx-web-framework/moryx-snackbar/src/moryx-snackbar/moryx-snackbar.service.ts
@@ -64,34 +64,39 @@ export class MoryxSnackbarService {
 
   async processStatusCodes(e: HttpErrorResponse) {
     let msg!: string;
-    if (e.status >= 500) {
-      msg = await this.translate.get(TranslationConstants.DEFAULT_MESSAGE).toAsync();
-    }
-    else if (e.status == 401) {
-      msg = await this.translate.get(TranslationConstants.HTTP_UNAUTHORIZED).toAsync();
-    }
-    else if (e.status == 403) {
-      if (Array.isArray(e.error) && e.error.length > 0) {
-        msg = await this.translate.get(TranslationConstants.MISSING_PERMISSION).toAsync();
-        msg += ": " + e.error.join(', ')
+
+    msg = e.error?.title
+    
+    if(msg === undefined) {
+      if (e.status >= 500) {
+        msg = await this.translate.get(TranslationConstants.DEFAULT_MESSAGE).toAsync();
       }
-      else
-        msg = await this.translate.get(TranslationConstants.HTTP_FORBIDDEN).toAsync();
-    }
-    else if (e.status == 404) {
-      msg = await this.translate.get(TranslationConstants.HTTP_NOT_FOUND).toAsync();
-    }
-    else if (e.status == 405) {
-      msg = await this.translate.get(TranslationConstants.HTTP_METHOD_NOT_ALLOWED).toAsync();
-    }
-    else if (e.status >= 400 && (typeof e.error === 'string' || e.error instanceof String)) {
-      msg = e.error as string;
-    }
-    else if (e.status >= 400) {
-      msg = await this.translate.get(TranslationConstants.HTTP_BAD_REQUEST).toAsync();
-    }
-    else {
-      msg = await this.translate.get(TranslationConstants.UNKNOWN_ERROR).toAsync();
+      else if (e.status == 401) {
+        msg = await this.translate.get(TranslationConstants.HTTP_UNAUTHORIZED).toAsync();
+      }
+      else if (e.status == 403) {
+        if (Array.isArray(e.error) && e.error.length > 0) {
+          msg = await this.translate.get(TranslationConstants.MISSING_PERMISSION).toAsync();
+          msg += ": " + e.error.join(', ')
+        }
+        else
+          msg = await this.translate.get(TranslationConstants.HTTP_FORBIDDEN).toAsync();
+      }
+      else if (e.status == 404) {
+        msg = await this.translate.get(TranslationConstants.HTTP_NOT_FOUND).toAsync();
+      }
+      else if (e.status == 405) {
+        msg = await this.translate.get(TranslationConstants.HTTP_METHOD_NOT_ALLOWED).toAsync();
+      }
+      else if (e.status >= 400 && (typeof e.error === 'string' || e.error instanceof String)) {
+        msg = e.error as string;
+      }
+      else if (e.status >= 400) {
+        msg = await this.translate.get(TranslationConstants.HTTP_BAD_REQUEST).toAsync();
+      }
+      else {
+        msg = await this.translate.get(TranslationConstants.UNKNOWN_ERROR).toAsync();
+      }
     }
 
     await this.showError(msg);


### PR DESCRIPTION
If the backend responds with an error.title, that should be displayed before falling back to generic status code specific messages.