### PR TITLE
Update `.build-and-publish.yml` to set prerelease version on ci builds

### DIFF
--- a/.github/workflows/.build-and-publish.yml
+++ b/.github/workflows/.build-and-publish.yml
@@ -54,6 +54,11 @@ jobs:
     - name: 🔧 npm install
       run: npm ci
 
+    - name: Set CI version
+      working-directory: ./projects/ngx-web-framework
+      run: npm version $(npm pkg get version | sed -e 's/"//g' )-$(echo ${{ github.ref_name }} | sed -e 's/\//-/g').${{ github.run_number }} --no-git-tag-version --no-commit-hooks
+      if: github.ref_type != 'tag'
+
     - name: 🔨 build `ngx-web-framework`
       working-directory: ./projects/ngx-web-framework
       run: npm run build


### PR DESCRIPTION
CI builds should have a unique version when published to the package repository which includes the branch and pipeline number.

This step will not executed for tags, since the 'original' version should be used then.