### PR TITLE
change empty possible values property to be text editor (Issue #463)

### DIFF
--- a/projects/moryx-web-app/src/app/entry-editor-demo/entry-editor-demo.component.html
+++ b/projects/moryx-web-app/src/app/entry-editor-demo/entry-editor-demo.component.html
@@ -6,6 +6,7 @@
 <mat-divider></mat-divider>
 <navigable-entry-editor [entry]="entry3" [disabled]="disabled" queryParam="entryEditor4"></navigable-entry-editor>
 <mat-divider></mat-divider>
+<navigable-entry-editor [entry]="entry4" [disabled]="disabled" queryParam="entryEditor5"></navigable-entry-editor>
 <div>
     <button mat-button color="primary" (click)="onToggle()">Toggle Disable</button>
 </div>

--- a/projects/moryx-web-app/src/app/entry-editor-demo/entry-editor-demo.component.ts
+++ b/projects/moryx-web-app/src/app/entry-editor-demo/entry-editor-demo.component.ts
@@ -1208,6 +1208,221 @@ export class EntryEditorDemoComponent implements OnInit {
     ]
   }
 
+
+  entry4: Entry = {
+      "displayName": "AssemblyCell",
+      "identifier": "AssemblyCell",
+      "description": null,
+      "value": {
+        "type": EntryValueType.Class,
+        "unitType": EntryUnitType.None,
+        "current": "AssemblyCell",
+        "default": "AssemblyCell",
+        "possible": null,
+        "isReadOnly": false
+      },
+      "validation": {
+        "minimum": -1.7976931348623157e+308,
+        "maximum": 1.7976931348623157e+308,
+        "regex": null,
+        "isRequired": false
+      },
+      "subEntries": [
+        {
+          "displayName": "Nominal Power",
+          "identifier": "NominalPower",
+          "description": null,
+          "value": {
+            "type": EntryValueType.Int32,
+            "unitType": EntryUnitType.None,
+            "current": "225",
+            "default": "0",
+            "possible": null,
+            "isReadOnly": true
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        },
+        {
+          "displayName": "CameraInterface",
+          "identifier": "CameraInterface",
+          "description": null,
+          "value": {
+            "type": EntryValueType.String,
+            "unitType": EntryUnitType.None,
+            "current": null,
+            "default": null,
+            "possible": [],
+            "isReadOnly": false
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        },
+        {
+          "displayName": "Material Identifier",
+          "identifier": "MaterialIdentifier",
+          "description": null,
+          "value": {
+            "type": EntryValueType.String,
+            "unitType": EntryUnitType.None,
+            "current": "0031465",
+            "default": null,
+            "possible": null,
+            "isReadOnly": true
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        },
+        {
+          "displayName": "Reservations",
+          "identifier": "Reservations",
+          "description": null,
+          "value": {
+            "type": EntryValueType.Collection,
+            "unitType": EntryUnitType.None,
+            "current": null,
+            "default": "String",
+            "possible": [
+              "String"
+            ],
+            "isReadOnly": false
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": [
+            {
+              "displayName": "String",
+              "identifier": "CREATED",
+              "description": null,
+              "value": {
+                "type": EntryValueType.String,
+                "unitType": EntryUnitType.None,
+                "current": "",
+                "default": "",
+                "possible": null,
+                "isReadOnly": false
+              },
+              "validation": {
+                "minimum": -1.7976931348623157e+308,
+                "maximum": 1.7976931348623157e+308,
+                "regex": null,
+                "isRequired": false
+              },
+              "subEntries": [],
+              "prototypes": []
+            }
+          ]
+        },
+        {
+          "displayName": "Instance Count",
+          "identifier": "InstanceCount",
+          "description": null,
+          "value": {
+            "type": EntryValueType.Int32,
+            "unitType": EntryUnitType.None,
+            "current": "0",
+            "default": "0",
+            "possible": null,
+            "isReadOnly": false
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        },
+        {
+          "displayName": "Manual Mode",
+          "identifier": "ManualMode",
+          "description": null,
+          "value": {
+            "type": EntryValueType.Boolean,
+            "unitType": EntryUnitType.None,
+            "current": "False",
+            "default": "False",
+            "possible": null,
+            "isReadOnly": false
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        },
+        {
+          "displayName": "State",
+          "identifier": "CellState",
+          "description": null,
+          "value": {
+            "type": EntryValueType.String,
+            "unitType": EntryUnitType.None,
+            "current": "Idle",
+            "default": null,
+            "possible": null,
+            "isReadOnly": false
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        },
+        {
+          "displayName": "Disabled",
+          "identifier": "Disabled",
+          "description": null,
+          "value": {
+            "type": EntryValueType.Boolean,
+            "unitType": EntryUnitType.None,
+            "current": "False",
+            "default": "False",
+            "possible": null,
+            "isReadOnly": false
+          },
+          "validation": {
+            "minimum": -1.7976931348623157e+308,
+            "maximum": 1.7976931348623157e+308,
+            "regex": null,
+            "isRequired": false
+          },
+          "subEntries": [],
+          "prototypes": []
+        }
+      ],
+      "prototypes": []
+    }
   ngOnInit(): void {}
 
   onToggle() {

--- a/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.html
@@ -64,7 +64,7 @@
                 <entry-input-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
                     [disabled]="disabled" *ngSwitchCase="
                                     (subEntry.value?.possible === null || 
-                                    subEntry.value?.possible === undefined ) &&
+                                    subEntry.value?.possible === undefined || !subEntry.value?.possible?.length) &&
                                     (EntryValueType.Byte === subEntry.value?.type ||
                                     EntryValueType.Int16 === subEntry.value?.type || 
                                     EntryValueType.UInt16 === subEntry.value?.type ||


### PR DESCRIPTION
Issue : https://github.com/PHOENIXCONTACT/MORYX-Framework/issues/463
Added an extra condition to use a text editor in case the the PossibleValues are empty array.