### PR TITLE
Refactor FormControl Value Handling Logic

### DIFF
--- a/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.ts
@@ -41,12 +41,14 @@ export class EnumEditorComponent implements OnInit {
   ngOnInit(): void {
     this._entry.value.current = this._entry.value?.current ?? this._entry.value?.default;
   }
-  
+
   changed(event: any) {
-    if (this._entry.value.unitType === EntryUnitType.Flags)
-      this._entry.value.current = this.FormControl.value?.join(",");
-    else {
-      this._entry.value.current = this.FormControl.value?.toString() ?? '';
+    if (Array.isArray(this.FormControl.value) && this.FormControl.value.length > 0) {
+      this._entry.value.current = this.FormControl.value.join(",");
+    } else if (typeof this.FormControl.value === 'string' && this.FormControl.value.trim().length > 0) {
+      this._entry.value.current = this.FormControl.value;
+    } else {
+      this._entry.value.current = "0";
     }
   }
 }


### PR DESCRIPTION
I noticed an error that occurs when you try to unselect everything from the dropdown of a `Enum` with the `FlagsAttribute` set (and then save). 

If `value` is `""` (empty string) the C# code `Enum.Parse(type, value);` will fail. This can be fixed by setting the default value to `"0"` (`null` would also work) in the `enum-editor.component`.

In theory this error would also affect normal `Enum`s without the attribute but it is currently not possible to unselect those in the UI.