### PR TITLE
SMAF-5292: Add type specification on buttons

### DIFF
--- a/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.html
@@ -14,6 +14,7 @@
   <button
     mat-icon-button
     class="entry-editor-add-list-item-button"
+    type="button"
     (click)="addItemToList()"
     [disabled]="disabled()"
     [ngClass]="{ disabled: disabled() }">

--- a/projects/ngx-web-framework/entry-editor/src/entry-list-item/entry-list-item.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-list-item/entry-list-item.component.html
@@ -55,6 +55,7 @@
     <button
       mat-icon-button
       class="entry-list-item-delete"
+      type="button"
       (click)="onDelete()"
       [disabled]="disabled()"
       [ngClass]="{ disabled: disabled }">

--- a/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.html
@@ -1,5 +1,5 @@
 <div class="entry-object-wrapper">
-  <button mat-stroked-button (click)="onOpen()" class="full-width-input entry-object-container">
+  <button mat-stroked-button (click)="onOpen()" class="full-width-input entry-object-container" type="button">
     <div class="entry-object">
       <span class="entry-object-text">{{ entry().displayName }}</span>
       <span class="material-symbols-outlined"> chevron_right </span>

--- a/projects/ngx-web-framework/entry-editor/src/file-editor/file-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/file-editor/file-editor.component.html
@@ -18,6 +18,7 @@
         mat-icon-button
         (click)="fileUpload.click()"
         class="file-input-button"
+        type="button"
         [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
         [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
         matSuffix>

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
@@ -94,6 +94,7 @@
 
     <button
       mat-icon-button
+      type="button"
       matSuffix
       class="code-button"
       [disabled]="inputFormControl.disabled"

--- a/projects/ngx-web-framework/package-lock.json
+++ b/projects/ngx-web-framework/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moryx/ngx-web-framework",
-  "version": "19.1.2",
+  "version": "19.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/ngx-web-framework/package.json
+++ b/projects/ngx-web-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moryx/ngx-web-framework",
-  "version": "19.1.2",
+  "version": "19.1.3",
   "scripts": {
     "ng": "ng",
     "build": "ng build",


### PR DESCRIPTION
Specify buttons with button-type to override the default type 'submit'