### PR TITLE
Integrate slider for numeric values with validation limits

### DIFF
--- a/projects/ngx-web-framework/entry-editor/src/entry-list-item/entry-list-item.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/entry-list-item/entry-list-item.component.ts
@@ -9,16 +9,25 @@ import { InputEditorComponent } from '../input-editor/input-editor.component';
 import { EnumEditorComponent } from '../enum-editor/enum-editor.component';
 import { CommonModule } from '@angular/common';
 import { MatLine } from '@angular/material/core';
-import { MatDivider } from '@angular/material/divider';
 import { MatIconButton } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
 
 @Component({
-    selector: 'entry-list-item',
-    templateUrl: './entry-list-item.component.html',
-    styleUrls: ['./entry-list-item.component.scss'],
-    standalone: true,
-    imports: [FileEditorComponent, EntryObjectComponent, BooleanEditorComponent, InputEditorComponent, EnumEditorComponent, CommonModule, MatLine, MatDivider, MatIconButton, MatListModule]
+  selector: 'entry-list-item',
+  templateUrl: './entry-list-item.component.html',
+  styleUrls: ['./entry-list-item.component.scss'],
+  standalone: true,
+  imports: [
+    FileEditorComponent,
+    EntryObjectComponent,
+    BooleanEditorComponent,
+    InputEditorComponent,
+    EnumEditorComponent,
+    CommonModule,
+    MatLine,
+    MatIconButton,
+    MatListModule,
+  ],
 })
 export class EntryListItemComponent {
   entry = input.required<Entry>();
@@ -26,16 +35,14 @@ export class EntryListItemComponent {
   disabled = input<boolean>(false);
   @Output() deleteRequest: EventEmitter<Entry> = new EventEmitter<Entry>();
   isObjectType = computed(() => {
-    return EntryValueType.Class === this.entry().value?.type || 
-           EntryValueType.Collection === this.entry().value?.type
-  })
-  
+    return EntryValueType.Class === this.entry().value?.type || EntryValueType.Collection === this.entry().value?.type;
+  });
+
   EntryValueType = EntryValueType;
   EntryUnitType = EntryUnitType;
-  constructor() { }
+  constructor() {}
 
-  onDelete(){
+  onDelete() {
     this.deleteRequest.emit(this.entry());
   }
-
 }

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
@@ -1,17 +1,31 @@
 <!-- SLIDER -->
-<ng-container *ngIf="shouldUseSlider() && !useTextArea(); else textInput">
+<div *ngIf="shouldUseSlider() && !useTextArea(); else textInput" class="slider-wrap">
   <label class="slider-label">{{ entry().displayName }}</label>
-  <mat-slider
-    class="entry-slider"
-    [min]="entry().validation?.minimum"
-    [max]="entry().validation?.maximum"
-    [step]="getSliderStep()"
-    [discrete]="true"
-    [disabled]="inputFormControl.disabled"
-    [showTickMarks]="true">
-    <input matSliderThumb [ngModel]="entry().value.current" (ngModelChange)="onSliderChange($event)" />
-  </mat-slider>
-</ng-container>
+
+  <div class="slider-row">
+    <mat-slider
+      class="entry-slider"
+      [min]="entry().validation?.minimum"
+      [max]="entry().validation?.maximum"
+      [step]="getSliderStep()"
+      [discrete]="!shouldShowInlineInput()"
+      [disabled]="inputFormControl.disabled"
+      [showTickMarks]="true">
+      <input matSliderThumb [ngModel]="entry().value.current" (ngModelChange)="onSliderChange($event)" />
+    </mat-slider>
+
+    <mat-form-field *ngIf="shouldShowInlineInput()" class="slider-inline-input" appearance="outline">
+      <input
+        matInput
+        type="number"
+        [step]="getSliderStep()"
+        [min]="entry().validation?.minimum!"
+        [max]="entry().validation?.maximum!"
+        [formControl]="inputFormControl"
+        [readonly]="readOnly()" />
+    </mat-form-field>
+  </div>
+</div>
 
 <!-- INPUT -->
 <ng-template #textInput>

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
@@ -1,41 +1,66 @@
-<mat-form-field class="full-width-input entry-form-field" appearance="outline">
-  <mat-label>{{ entry().displayName }}</mat-label>
-  <input
-    *ngIf="!useTextArea()"
-    aria-label="Text field for changing an entry value."
-    [type]="isPassword ? 'password' : isNumber ? 'number' : 'text'"
-    [attr.min]="isNumber ? entry().validation?.minimum : null"
-    [attr.max]="isNumber ? entry().validation?.maximum : null"
-    [placeholder]="entry().description ?? 'No description available'"
-    [readonly]="readOnly()"
-    matInput
-    [formControl]="inputFormControl" />
-  <textarea matInput 
-    [placeholder]="entry().description ?? 'No description available'" 
-    *ngIf="useTextArea()" 
-    rows="5"
-    [formControl]="inputFormControl">
-  </textarea>
-  <button mat-icon-button matSuffix 
-    class="code-button"
-    [attr.aria-label]="'html editor'" 
-    (click)="setTextArea(!useTextArea())"
-    *ngIf="!isPassword && !isNumber && !readOnly() && !useTextArea()">
-    <mat-icon>code</mat-icon>
-  </button>
+<!-- SLIDER -->
+<ng-container *ngIf="shouldUseSlider() && !useTextArea(); else textInput">
+  <label class="slider-label">{{ entry().displayName }}</label>
+  <mat-slider
+    class="entry-slider"
+    [min]="entry().validation?.minimum"
+    [max]="entry().validation?.maximum"
+    [step]="getSliderStep()"
+    [discrete]="true"
+    [disabled]="inputFormControl.disabled"
+    [showTickMarks]="true">
+    <input matSliderThumb [ngModel]="entry().value.current" (ngModelChange)="onSliderChange($event)" />
+  </mat-slider>
+</ng-container>
+
+<!-- INPUT -->
+<ng-template #textInput>
+  <mat-form-field class="full-width-input entry-form-field" appearance="outline">
+    <mat-label>{{ entry().displayName }}</mat-label>
+    <input
+      *ngIf="!useTextArea()"
+      aria-label="Text field for changing an entry value."
+      [type]="isPassword ? 'password' : isNumber ? 'number' : 'text'"
+      [attr.min]="isNumber ? entry().validation?.minimum : null"
+      [attr.max]="isNumber ? entry().validation?.maximum : null"
+      [placeholder]="entry().description ?? 'No description available'"
+      [readonly]="readOnly()"
+      matInput
+      [formControl]="inputFormControl" />
+
     <mat-error *ngIf="inputFormControl.hasError('min')" class="truncate">
-        Please enter a value higher than {{entry().validation?.minimum}}
+      Please enter a value higher than {{ entry().validation?.minimum }}
     </mat-error>
     <mat-error *ngIf="inputFormControl.hasError('max')" class="truncate">
-        Please enter a value lower than {{entry().validation?.maximum}}
+      Please enter a value lower than {{ entry().validation?.maximum }}
     </mat-error>
     <mat-error *ngIf="inputFormControl.hasError('pattern')" class="truncate">
-        Please make sure your input matches the following pattern: {{entry().validation?.regex}}
+      Please make sure your input matches the pattern: {{ entry().validation?.regex }}
     </mat-error>
     <mat-error *ngIf="inputFormControl.hasError('required')" class="truncate">
-        {{entry().displayName}} is <strong>required</strong>
+      {{ entry().displayName }} is <strong>required</strong>
     </mat-error>
-    <mat-error *ngIf="inputFormControl.hasError('invalidEntryValue')" class="block" class="truncate">
-        The entered value is <strong>invalid</strong>
+    <mat-error *ngIf="inputFormControl.hasError('invalidEntryValue')" class="block truncate">
+      The entered value is <strong>invalid</strong>
     </mat-error>
-</mat-form-field>
+
+    <!-- TEXTAREA -->
+    <textarea
+      matInput
+      [placeholder]="entry().description ?? 'No description available'"
+      *ngIf="useTextArea()"
+      rows="5"
+      [formControl]="inputFormControl"></textarea>
+
+    <button
+      mat-icon-button
+      matSuffix
+      class="code-button"
+      [disabled]="inputFormControl.disabled"
+      [attr.aria-label]="'html editor'"
+      (click)="setTextArea(!useTextArea())"
+      *ngIf="!isPassword && !isNumber && !readOnly() && !useTextArea()">
+      <mat-icon>code</mat-icon>
+    </button>
+  </mat-form-field>
+</ng-template>

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.scss
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.scss
@@ -1,8 +1,43 @@
 @use "../entry-editor.scss" as *;
-.block{
-    display: block !important;
+
+.block {
+  display: block !important;
 }
 
 .code-button {
-    margin-right: 5px;
+  margin-right: 5px;
+}
+
+.slider-wrap {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.slider-label {
+  margin-bottom: 6px;
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 12px;
+}
+
+.entry-slider {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.slider-inline-input {
+  width: 112px;
+  
+  ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
+
+  ::ng-deep .mat-mdc-form-field-flex {
+    align-items: center;
+  }
 }

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
@@ -44,6 +44,7 @@ export class InputEditorComponent implements OnDestroy {
   readOnly = signal<boolean>(false);
   disabled = input<boolean>(false);
   entry = model.required<Entry>();
+  private readonly INLINE_INPUT_RANGE_THRESHOLD = 100;
 
   constructor() {
     this.inputFormControl = new UntypedFormControl();
@@ -233,5 +234,21 @@ export class InputEditorComponent implements OnDestroy {
       default:
         return 1;
     }
+  }
+
+  private getRange(): number {
+    const min = this.entry().validation?.minimum ?? 0;
+    const max = this.entry().validation?.maximum ?? 0;
+    return max - min;
+  }
+
+  private maxDigits(): number {
+    const minAbs = Math.abs(this.entry().validation?.minimum ?? 0);
+    const maxAbs = Math.abs(this.entry().validation?.maximum ?? 0);
+    return Math.max(minAbs, maxAbs).toString().length;
+  }
+
+  shouldShowInlineInput(): boolean {
+    return this.isNumber && (this.getRange() > this.INLINE_INPUT_RANGE_THRESHOLD || this.maxDigits() > 3);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
@@ -211,16 +211,26 @@ export class InputEditorComponent implements OnDestroy {
   }
 
   shouldUseSlider(): boolean {
-    if (!this.isNumber) return false;
-    const min = this.entry().validation?.minimum;
-    const max = this.entry().validation?.maximum;
-    if (min == null || max == null) return false;
+  const entryData = this.entry();
 
-    const typeMin = this.getTypeSpecificMinimum(this.entry().value.type);
-    const typeMax = this.getTypeSpecificMaximum(this.entry().value.type);
-
-    return min > typeMin || max < typeMax;
+  if ((entryData as any).value.useSlider === false) {
+    return false;
   }
+
+  return this.defaultSliderCheck(entryData);
+}
+
+private defaultSliderCheck(entryData: Entry): boolean {
+  if (!this.isNumber) return false;
+  const min = entryData.validation?.minimum;
+  const max = entryData.validation?.maximum;
+  if (min == null || max == null) return false;
+
+  const typeMin = this.getTypeSpecificMinimum(entryData.value.type);
+  const typeMax = this.getTypeSpecificMaximum(entryData.value.type);
+
+  return min > typeMin || max < typeMax;
+}
 
   onSliderChange(value: number) {
     this.inputFormControl.setValue(value);

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
@@ -15,6 +15,7 @@ import { MatError, MatFormFieldModule, MatLabel } from '@angular/material/form-f
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSlider, MatSliderModule } from '@angular/material/slider';
 
 @Component({
   selector: 'entry-input-editor',
@@ -30,7 +31,8 @@ import { MatButtonModule } from '@angular/material/button';
     MatFormFieldModule,
     MatInputModule,
     MatIconModule,
-    MatButtonModule
+    MatButtonModule,
+    MatSliderModule,
   ],
 })
 export class InputEditorComponent implements OnDestroy {
@@ -56,7 +58,9 @@ export class InputEditorComponent implements OnDestroy {
   }
 
   initialize(entry: Entry) {
-    this.readOnly.set(entry.value?.isReadOnly || this.isSinglePossibleValue(entry) || entry.value.type === EntryValueType.Exception);
+    this.readOnly.set(
+      entry.value?.isReadOnly || this.isSinglePossibleValue(entry) || entry.value.type === EntryValueType.Exception
+    );
     this.updateCurrentValue(entry.value, entry.value.current);
     this.determineInputType();
 
@@ -67,32 +71,29 @@ export class InputEditorComponent implements OnDestroy {
   private updateCurrentValue(currentValue: EntryValue, value: any) {
     this.entry.update(e => {
       let copy = Object.assign({}, e);
-      copy.value.current = this.isSinglePossibleValue(e) ? (e.value.possible ?? [''])[0] : value ?? currentValue?.default;
+      copy.value.current = this.isSinglePossibleValue(e)
+        ? (e.value.possible ?? [''])[0]
+        : value ?? currentValue?.default;
       return copy;
     });
   }
 
-  isSinglePossibleValue(entry: Entry): boolean{
-    const result =  entry.value.possible && entry.value.possible.length === 1
+  isSinglePossibleValue(entry: Entry): boolean {
+    const result = entry.value.possible && entry.value.possible.length === 1;
     return result ?? false;
   }
 
   disableInputFormControl(control: UntypedFormControl, disable: boolean) {
-    if (disable)
-      control.disable();
-    else 
-      control.enable();
+    if (disable) control.disable();
+    else control.enable();
   }
 
   setupValidators(entry: Entry): ValidatorFn[] {
     var validators = [] as ValidatorFn[];
     validators.push(invalidEntryValueValidator(entry.value.type));
-    if (entry.validation?.isRequired)
-      validators.push(Validators.required);
-    if (this.isNumber)
-      this.addNumberValidators(validators);
-    else
-      this.addTextValidators(validators);
+    if (entry.validation?.isRequired) validators.push(Validators.required);
+    if (this.isNumber) this.addNumberValidators(validators);
+    else this.addTextValidators(validators);
 
     return validators;
   }
@@ -101,18 +102,19 @@ export class InputEditorComponent implements OnDestroy {
     const result = new UntypedFormControl(
       {
         value: entry.value?.current ?? entry.value?.default ?? '',
-        disabled: this.disabled() || (entry.value.isReadOnly ?? false)
-      }, validators);
+        disabled: this.disabled() || (entry.value.isReadOnly ?? false),
+      },
+      validators
+    );
 
     this.formControlSubscription = result.valueChanges.subscribe(value => {
-      if (result.status == 'VALID'){
+      if (result.status == 'VALID') {
         this.updateCurrentValue(this.entry().value, value);
       }
     });
 
     return result;
   }
-
 
   ngOnDestroy(): void {
     this.formControlSubscription?.unsubscribe();
@@ -204,6 +206,32 @@ export class InputEditorComponent implements OnDestroy {
   }
 
   setTextArea(value: boolean) {
-   this.useTextArea.set(value);
+    this.useTextArea.set(value);
+  }
+
+  shouldUseSlider(): boolean {
+    if (!this.isNumber) return false;
+    const min = this.entry().validation?.minimum;
+    const max = this.entry().validation?.maximum;
+    if (min == null || max == null) return false;
+
+    const typeMin = this.getTypeSpecificMinimum(this.entry().value.type);
+    const typeMax = this.getTypeSpecificMaximum(this.entry().value.type);
+
+    return min > typeMin || max < typeMax;
+  }
+
+  onSliderChange(value: number) {
+    this.inputFormControl.setValue(value);
+  }
+
+  getSliderStep(): number {
+    switch (this.entry().value.type) {
+      case EntryValueType.Single:
+      case EntryValueType.Double:
+        return 0.1;
+      default:
+        return 1;
+    }
   }
 }

--- a/projects/ngx-web-framework/entry-editor/src/models/entry-value.ts
+++ b/projects/ngx-web-framework/entry-editor/src/models/entry-value.ts
@@ -6,6 +6,7 @@ export interface EntryValue {
   current?: null | string;
   default?: null | string;
   isReadOnly?: boolean;
+  useSlider?: boolean;
   possible?: null | Array<string>;
   type?: EntryValueType;
   unitType?: EntryUnitType;


### PR DESCRIPTION
### Summary

This PR adds support for displaying a `mat-slider` for numeric entry types in the `EntryEditorComponent`, whenever the entry has explicit validation boundaries (`min`/`max`) that differ from the default type limits.
This allows a more intuitive and constrained editing experience for numeric values with known boundaries, while preserving the familiar UI and form behavior.

### Changes
- Introduced `shouldUseSlider()` method to determine when a slider should be shown
- Added `mat-slider` with `matSliderThumb` bound to the entry value
- Kept the original layout and behavior of the input/textarea structure