### PR TITLE
SMAF-5176: Show descriptions as hints across EntryEditor and show defaults as placeholders

### DIFF
--- a/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.html
@@ -1,73 +1,115 @@
-<div *ngIf="disabled() === false && EntryValueType.Collection === entry().value?.type" class="entry-editor-add-list-item">
-    <mat-form-field class="entry-editor-add-list-item-type-selector" appearance="outline">
-        <mat-label>Select the type of object</mat-label>
+<div
+  *ngIf="disabled() === false && EntryValueType.Collection === entry().value?.type"
+  class="entry-editor-add-list-item">
+  <mat-form-field class="entry-editor-add-list-item-type-selector" appearance="outline">
+    <mat-label>Select the type of object</mat-label>
 
-        <mat-select [(ngModel)]="selectedListItemType">
-            <mat-option *ngFor="let pv of possibleListItemTypes()" [value]="pv">
-                {{pv}}
-            </mat-option>
-        </mat-select>
-    </mat-form-field>
+    <mat-select [(ngModel)]="selectedListItemType">
+      <mat-option *ngFor="let pv of possibleListItemTypes()" [value]="pv">
+        {{ pv }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
 
-    <button mat-icon-button class="entry-editor-add-list-item-button" (click)="addItemToList()" [disabled]="disabled()"
-        [ngClass]="{'disabled': disabled()}">
-        <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_add</span>
-    </button>
+  <button
+    mat-icon-button
+    class="entry-editor-add-list-item-button"
+    (click)="addItemToList()"
+    [disabled]="disabled()"
+    [ngClass]="{ disabled: disabled() }">
+    <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_add</span>
+  </button>
 </div>
 
-<div class="settable-dropdown-entry"  *ngIf="isEntryTypeSettable(entry())">
-    <mat-form-field  appearance="outline" class="settable-dropdown-entry-selector">
-        <mat-label>{{entry().displayName}}</mat-label>
+<div class="settable-dropdown-entry" *ngIf="isEntryTypeSettable(entry())">
+  <mat-form-field appearance="outline" class="settable-dropdown-entry-selector">
+    <mat-label>{{ entry().displayName }}</mat-label>
 
-        <mat-select [disabled]="disabled() || (entry().value.isReadOnly ?? false)" [(ngModel)]="entry().value.current" 
-        (selectionChange)="dropdownSelectionChanged($event)">
-            <mat-option *ngFor="let pv of entry().value?.possible" [value]="pv">
-                {{pv}}
-            </mat-option>
-        </mat-select>
-    </mat-form-field>
+    <mat-select
+      [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
+      [(ngModel)]="entry().value.current"
+      (selectionChange)="dropdownSelectionChanged($event)">
+      <mat-option *ngFor="let pv of entry().value?.possible" [value]="pv">
+        {{ pv }}
+      </mat-option>
+    </mat-select>
+    <mat-hint
+      [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+      class="truncate">
+      {{ entry().description }}
+    </mat-hint>
+  </mat-form-field>
 </div>
 @if(entry().subEntries?.length){
-    <mat-list class="entry-editor-subentries-list">
-        <ng-container *ngFor="let subEntry of entry().subEntries">
-            <ng-container *ngIf="EntryValueType.Collection === entry().value?.type; else elseBlock">
-                <ng-container *ngIf="editorId()">
-                    <entry-list-item matLine class="entry-editor-subentries-list-item" [editorId]="editorId()!" [entry]="subEntry" [disabled]="disabled()"
-                        (deleteRequest)="onDeleteListItem($event)">
-                    </entry-list-item>
-                </ng-container>
-            </ng-container>
-            <ng-template #elseBlock>
-                <ng-container [ngSwitch]="true">
-                    <entry-file-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry" (entryChange)="updateSubEntry($event)"
-                        [disabled]="disabled()" *ngSwitchCase="EntryValueType.Stream === subEntry.value?.type">
-                    </entry-file-editor>
-                    <ng-container *ngIf="editorId()">
-                        <entry-object-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"  [editorId]="editorId()!"
-                            *ngIf="EntryValueType.Class === subEntry.value?.type || EntryValueType.Collection === subEntry.value?.type">
-                            ></entry-object-editor>
-                    </ng-container>
-                    <entry-boolean-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
-                        (entryChange)="updateSubEntry($event)"
-                        [disabled]="disabled()" *ngSwitchCase="EntryValueType.Boolean === subEntry.value?.type">
-                    </entry-boolean-editor>
-                    <!-- To display a dropdown the entry should have possible value greate than 1, except collections and Class
-                      since both have possible values but are already handle in cases above -->
-                    <entry-enum-editor matLine class="entry-editor-subentries-list-item"
-                    [entry]="subEntry"
-                    (entryChange)="updateSubEntry($event)"
-                    [disabled]="disabled()" 
-                    *ngSwitchCase="EntryValueType.Enum === subEntry.value.type || 
-                                   (subEntry.value.possible && subEntry.value.possible.length > 1) &&
-                                   (subEntry.value?.type !== EntryValueType.Collection && !isEntryTypeSettable(subEntry))">
-                    </entry-enum-editor>
-                    <entry-input-editor matLine class="entry-editor-subentries-list-item" 
-                    [entry]="subEntry" (entryChange)="updateSubEntry($event)"
-                        [disabled]="disabled()" 
-                        *ngSwitchCase="isPrimitiveType(subEntry)">
-                    </entry-input-editor>
-                </ng-container>
-            </ng-template>
+<mat-list class="entry-editor-subentries-list">
+  <ng-container *ngFor="let subEntry of entry().subEntries">
+    <ng-container *ngIf="EntryValueType.Collection === entry().value?.type; else elseBlock">
+      <ng-container *ngIf="editorId()">
+        <entry-list-item
+          matLine
+          class="entry-editor-subentries-list-item"
+          [editorId]="editorId()!"
+          [entry]="subEntry"
+          [disabled]="disabled()"
+          (deleteRequest)="onDeleteListItem($event)">
+        </entry-list-item>
+      </ng-container>
+    </ng-container>
+    <ng-template #elseBlock>
+      <ng-container [ngSwitch]="true">
+        <entry-file-editor
+          matLine
+          class="entry-editor-subentries-list-item"
+          [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)"
+          [disabled]="disabled()"
+          *ngSwitchCase="EntryValueType.Stream === subEntry.value?.type">
+        </entry-file-editor>
+        <ng-container *ngIf="editorId()">
+          <entry-object-editor
+            matLine
+            class="entry-editor-subentries-list-item"
+            [entry]="subEntry"
+            [editorId]="editorId()!"
+            [disabled]="disabled()"
+            *ngIf="EntryValueType.Class === subEntry.value?.type || EntryValueType.Collection === subEntry.value?.type">
+            ></entry-object-editor
+          >
         </ng-container>
-    </mat-list>
+        <entry-boolean-editor
+          matLine
+          class="entry-editor-subentries-list-item"
+          [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)"
+          [disabled]="disabled()"
+          *ngSwitchCase="EntryValueType.Boolean === subEntry.value?.type">
+        </entry-boolean-editor>
+        <!-- To display a dropdown the entry should have possible value greate than 1, except collections and Class
+                      since both have possible values but are already handle in cases above -->
+        <entry-enum-editor
+          matLine
+          class="entry-editor-subentries-list-item"
+          [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)"
+          [disabled]="disabled()"
+          *ngSwitchCase="
+            EntryValueType.Enum === subEntry.value.type ||
+            (subEntry.value.possible &&
+              subEntry.value.possible.length > 1 &&
+              subEntry.value?.type !== EntryValueType.Collection &&
+              !isEntryTypeSettable(subEntry))
+          ">
+        </entry-enum-editor>
+        <entry-input-editor
+          matLine
+          class="entry-editor-subentries-list-item"
+          [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)"
+          [disabled]="disabled()"
+          *ngSwitchCase="isPrimitiveType(subEntry)">
+        </entry-input-editor>
+      </ng-container>
+    </ng-template>
+  </ng-container>
+</mat-list>
 }

--- a/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.ts
@@ -7,7 +7,7 @@ import { BooleanEditorComponent } from '../boolean-editor/boolean-editor.compone
 import { MatLineModule, MatOption } from '@angular/material/core';
 import { CommonModule, NgClass, NgFor, NgIf, NgSwitch } from '@angular/common';
 import { MatList } from '@angular/material/list';
-import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
 import { MatSelect, MatSelectChange } from '@angular/material/select';
 import { FormsModule, NgModel } from '@angular/forms';
 import { EnumEditorComponent } from '../enum-editor/enum-editor.component';
@@ -41,8 +41,9 @@ import { MatIconButton } from '@angular/material/button';
     NgFor,
     CommonModule,
     FormsModule,
-    MatIconButton
-  ],
+    MatIconButton,
+    MatHint
+],
 })
 export class EntryEditorComponent {
   editorId = input<number | undefined>(undefined);

--- a/projects/ngx-web-framework/entry-editor/src/entry-list-item/entry-list-item.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-list-item/entry-list-item.component.html
@@ -13,6 +13,7 @@
         class="entry-list-item-value"
         [entry]="entry()"
         [editorId]="editorId()"
+        [disabled]="disabled()"
         *ngIf="EntryValueType.Class === entry().value?.type || EntryValueType.Collection === entry().value?.type">
         ></entry-object-editor
       >
@@ -60,5 +61,4 @@
       <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_remove</span>
     </button>
   </div>
-
 </div>

--- a/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.html
@@ -1,6 +1,12 @@
-<button mat-stroked-button (click)="onOpen()" class="full-width-input entry-object-container">
-  <div class="entry-object">
-    <span class="entry-object-text">{{ entry().displayName }}</span>
-    <span class="material-symbols-outlined"> chevron_right </span>
+<div class="entry-object-wrapper">
+  <button mat-stroked-button (click)="onOpen()" class="full-width-input entry-object-container">
+    <div class="entry-object">
+      <span class="entry-object-text">{{ entry().displayName }}</span>
+      <span class="material-symbols-outlined"> chevron_right </span>
+    </div>
+  </button>
+
+  <div class="object-entry-hint" [class.entry-editor-disabled]="disabled() || (entry().value.isReadOnly ?? false)">
+    {{ entry().description }}
   </div>
-</button>
+</div>

--- a/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.scss
+++ b/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.scss
@@ -1,19 +1,42 @@
 @use "../entry-editor.scss";
 
-.entry-object{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    height: 100%;
+.entry-object-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
 }
 
-.entry-object-container{
-    height: 42px;
-    margin-bottom:  22px;
-    border-radius: 4px;
+.entry-object {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 40px;
 }
+
 .entry-object-text {
-    padding-right: 8px;
+  padding-right: 8px;
+}
+
+.entry-object-container {
+  width: 100%;
+  align-self: stretch;
+  box-sizing: border-box;
+  margin-bottom: 0;
+  border-radius: 4px;
+}
+
+.object-entry-hint {
+  display: block;
+  width: 100%;
+  font-size: 12px;
+  line-height: 16px;
+  margin-top: 4px;
+  padding-left: 16px;
+}
+
+.entry-editor-disabled {
+  opacity: 0.6;
 }

--- a/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/entry-object/entry-object.component.ts
@@ -14,6 +14,7 @@ export class EntryObjectComponent {
   
   entry = input.required<Entry>();
   editorId = input.required<number>();
+  disabled = input<boolean>(false);
 
   constructor(private service: NavigableEntryService) { }
 

--- a/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.html
@@ -1,12 +1,11 @@
 <mat-form-field class="full-width-input entry-form-field" appearance="outline">
-    <mat-label>{{entry().displayName}}</mat-label>
-    <mat-select [formControl]="FormControl" (selectionChange)="changed($event)"
-        [multiple]="isFlagEnum()">
-        <mat-option *ngFor="let pv of entry().value?.possible" [value]="pv">
-            {{pv}}
-        </mat-option>
-    </mat-select>
-    <mat-hint [ngClass]="{'entry-editor-disabled': (disabled() || (entry().value.isReadOnly ?? false))}" class="truncate">
-        {{entry().description}}
-    </mat-hint>
+  <mat-label>{{ entry().displayName }}</mat-label>
+  <mat-select [formControl]="FormControl" (selectionChange)="changed($event)" [multiple]="isFlagEnum()">
+    <mat-option *ngFor="let pv of entry().value?.possible ?? []" [value]="pv">
+      {{ pv }}
+    </mat-option>
+  </mat-select>
+  <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }" class="truncate">
+    {{ entry().description }}
+  </mat-hint>
 </mat-form-field>

--- a/projects/ngx-web-framework/entry-editor/src/file-editor/file-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/file-editor/file-editor.component.html
@@ -1,19 +1,36 @@
 <div class="file-editor-container">
-    <input title="File Selector" type="file" class="file-input" (change)="onFileSelected($event)" #fileUpload />
-    <div class="moryx-file-input file-upload">
-        <mat-form-field appearance="outline" class="file-input-field entry-form-field">
-            <mat-label>{{entry().displayName}}</mat-label>
-            <input matInput [formControl]="inputFormControl"
-                aria-label="Text field for selecting a file path." title="Filename" class="file-input-field" />
-        <button mat-icon-button (click)="fileUpload.click()" class="file-input-button"
-            [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-            [ngClass]="{'entry-editor-disabled': (disabled() || (entry().value.isReadOnly ?? false))}"
-          matSuffix >
-            <span class="material-symbols-outlined">upload</span>
-        </button>
-      </mat-form-field>
-    </div>
-    <mat-error *ngIf="inputFormControl.hasError('required')" class="truncate">
-        {{entry().displayName}} is <strong>required</strong>
-    </mat-error>
+  <input title="File Selector" type="file" class="file-input" (change)="onFileSelected($event)" #fileUpload />
+  <div class="moryx-file-input file-upload">
+    <mat-form-field appearance="outline" class="file-input-field entry-form-field">
+      <mat-label>{{ entry().displayName }}</mat-label>
+      <input
+        matInput
+        [formControl]="inputFormControl"
+        aria-label="Text field for selecting a file path."
+        title="Filename"
+        class="file-input-field"
+        [placeholder]="
+          inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+            ? entry().value.default ?? ''
+            : ''
+        " />
+      <button
+        mat-icon-button
+        (click)="fileUpload.click()"
+        class="file-input-button"
+        [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
+        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+        matSuffix>
+        <span class="material-symbols-outlined">upload</span>
+      </button>
+      <mat-hint
+        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+        class="truncate">
+        {{ entry().description }}
+      </mat-hint>
+    </mat-form-field>
+  </div>
+  <mat-error *ngIf="inputFormControl.hasError('required')" class="truncate">
+    {{ entry().displayName }} is <strong>required</strong>
+  </mat-error>
 </div>

--- a/projects/ngx-web-framework/entry-editor/src/file-editor/file-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/file-editor/file-editor.component.ts
@@ -64,17 +64,19 @@ export class FileEditorComponent {
   }
 
   private setupFormControl(entry: Entry, validators: ValidatorFn[]): UntypedFormControl {
-    let result = new UntypedFormControl(
-      {
-        value: entry.description ?? '',
-        disabled: this.disabled 
-          || (entry.value.isReadOnly ?? false) 
-          || entry.value?.type === EntryValueType.Stream
-      }, 
-      validators);
+    const initial = entry.value?.current ?? '';
 
-    return result;
-  }
+    const ctrl = new UntypedFormControl(
+      {
+        value: initial,
+        disabled: this.disabled() || (entry.value.isReadOnly ?? false) || entry.value?.type === EntryValueType.Stream,
+      },
+      validators
+    );
+
+    return ctrl;
+}
+
 
   onFileSelected(event: any){
     const file:File = event.target.files[0];

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.html
@@ -11,7 +11,14 @@
       [discrete]="!shouldShowInlineInput()"
       [disabled]="inputFormControl.disabled"
       [showTickMarks]="true">
-      <input matSliderThumb [ngModel]="entry().value.current" (ngModelChange)="onSliderChange($event)" />
+      <input
+        matSliderThumb
+        [ngModel]="
+          inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+            ? entry().validation?.minimum ?? 0
+            : +inputFormControl.value
+        "
+        (ngModelChange)="inputFormControl.setValue($event)" />
     </mat-slider>
 
     <mat-form-field *ngIf="shouldShowInlineInput()" class="slider-inline-input" appearance="outline">
@@ -22,7 +29,12 @@
         [min]="entry().validation?.minimum!"
         [max]="entry().validation?.maximum!"
         [formControl]="inputFormControl"
-        [readonly]="readOnly()" />
+        [readonly]="readOnly()"
+        [placeholder]="
+          inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+            ? entry().value.default ?? ''
+            : ''
+        " />
     </mat-form-field>
   </div>
 </div>
@@ -37,10 +49,20 @@
       [type]="isPassword ? 'password' : isNumber ? 'number' : 'text'"
       [attr.min]="isNumber ? entry().validation?.minimum : null"
       [attr.max]="isNumber ? entry().validation?.maximum : null"
-      [placeholder]="entry().description ?? 'No description available'"
+      [placeholder]="
+        inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+          ? entry().value.default ?? ''
+          : ''
+      "
       [readonly]="readOnly()"
       matInput
       [formControl]="inputFormControl" />
+
+    <mat-hint
+      [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+      class="truncate">
+      {{ entry().description }}
+    </mat-hint>
 
     <mat-error *ngIf="inputFormControl.hasError('min')" class="truncate">
       Please enter a value higher than {{ entry().validation?.minimum }}
@@ -61,7 +83,11 @@
     <!-- TEXTAREA -->
     <textarea
       matInput
-      [placeholder]="entry().description ?? 'No description available'"
+      [placeholder]="
+        inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+          ? entry().value.default ?? ''
+          : ''
+      "
       *ngIf="useTextArea()"
       rows="5"
       [formControl]="inputFormControl"></textarea>

--- a/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/input-editor/input-editor.component.ts
@@ -232,10 +232,6 @@ private defaultSliderCheck(entryData: Entry): boolean {
   return min > typeMin || max < typeMax;
 }
 
-  onSliderChange(value: number) {
-    this.inputFormControl.setValue(value);
-  }
-
   getSliderStep(): number {
     switch (this.entry().value.type) {
       case EntryValueType.Single:


### PR DESCRIPTION
This PR makes property descriptions visible as “hints” beneath all controls in the Angular EntryEditor and ensures default values are shown as placeholders when the previous value was removed. It also standardizes the disabled/readOnly appearance of hints.