### PR TITLE
Fix potential issue with value being set to 0 in EnumEditorComponent

### DIFF
--- a/projects/moryx-web-app/src/app/entry-editor-demo/entry-editor-demo.component.ts
+++ b/projects/moryx-web-app/src/app/entry-editor-demo/entry-editor-demo.component.ts
@@ -323,7 +323,7 @@ export class EntryEditorDemoComponent implements OnInit {
           isReadOnly: false,
           possible: undefined,
           type: EntryValueType.Stream,
-          unitType: EntryUnitType.File,
+          unitType: EntryUnitType.FilePath,
         },
       },
       {
@@ -337,7 +337,7 @@ export class EntryEditorDemoComponent implements OnInit {
           isReadOnly: true,
           possible: undefined,
           type: EntryValueType.Stream,
-          unitType: EntryUnitType.File,
+          unitType: EntryUnitType.FilePath,
         },
       },
       {

--- a/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.html
+++ b/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.html
@@ -1,8 +1,8 @@
 <mat-form-field class="full-width-input entry-form-field" appearance="outline">
   <mat-label>{{ entry().displayName }}</mat-label>
   <mat-select [formControl]="FormControl" (selectionChange)="changed($event)" [multiple]="isFlagEnum()">
-    <mat-option *ngFor="let pv of entry().value?.possible ?? []" [value]="pv">
-      {{ pv.key}}
+    <mat-option *ngFor="let pv of entry().value?.possible ?? []" [value]="pv.key">
+      {{ pv.displayName ?? pv.key }}
     </mat-option>
   </mat-select>
   <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }" class="truncate">

--- a/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/enum-editor/enum-editor.component.ts
@@ -59,6 +59,7 @@ export class EnumEditorComponent {
         return e;
       });
     } else {
+      console.warn("EnumEditorComponent: No value selected, value is now set to 0");
       this.entry.update(e => {
         e.value.current = "0";
         return e;


### PR DESCRIPTION
### Summary
(In PossibleValue, Enums) The dropdown value was bound to the `{key: string, displayName: string}` object instead of the `key` value which let to the entryeditor setting `0` as the value since object are not handled.

 Now the value is bound to the key.

### Linked Issues

<!-- 
Link to any related issues using GitHub keywords (e.g., Fixes #123, Closes #456).
-->

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs. Please use code blocks (```) to format console output, logs, and code.
-->

### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [ ] I have tested these changes locally
- [ ] I have updated documentation as needed
- [ ] I have added or updated tests as appropriate
- [ ] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets
