### PR TITLE
change string to object for prototype selection

### DIFF
--- a/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.ts
+++ b/projects/ngx-web-framework/entry-editor/src/entry-editor/entry-editor.component.ts
@@ -143,10 +143,10 @@ export class EntryEditorComponent {
             entry.value.possible.length > 1;
   }
 
-  onPatchToSelectedEntryType(identifier: string): void {
+  onPatchToSelectedEntryType(keyPair: EntryPossible): void {
     this.entry.update(entry => {
       entry.subEntries = [];
-      const prototype = entry?.prototypes?.find((proto: Entry) => proto.displayName === identifier);
+      const prototype = entry?.prototypes?.find((proto: Entry) => proto.identifier === keyPair.key);
       if (!prototype) {
         this.selectedEntryHasPrototypes.set(false);
         return entry;


### PR DESCRIPTION
# Problem
Changes made in the backend from enum (string) type to object (key,displayName) , introduced a new bug which the prototype selection could not handle.

# Solution
Now the prototype selection handles object instead of string