### PR TITLE
Mark and resolve issues with zoneless entry editor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,14 +6,14 @@
       "name": "Launch Edge",
       "type": "pwa-msedge",
       "request": "launch",
-      "preLaunchTask": "npm: start",
+      "preLaunchTask": "npm: start-demo",
       "url": "http://localhost:4200/"
     },
     {
       "name": "ng serve",
       "type": "pwa-chrome",
       "request": "launch",
-      "preLaunchTask": "npm: start",
+      "preLaunchTask": "npm: start-demo",
       "url": "http://localhost:4200/"
     },
     {

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
@@ -1,13 +1,17 @@
-<navigable-entry-editor [entry]="testEntry" [disabled]="disabled" queryParam="entryEditor1"></navigable-entry-editor>
+<navigable-entry-editor [entry]="testEntry()" (entryChange)="onEntryChange($event)" [disabled]="disabled()" queryParam="entryEditor1"></navigable-entry-editor>
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="tcpDriverSampleEntry" [disabled]="disabled" queryParam="entryEditor3"></navigable-entry-editor>
+<navigable-entry-editor [entry]="testEntry()" (entryChange)="onEntryChange($event)" [disabled]="true" queryParam="entryEditor2"></navigable-entry-editor>
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="acquiredCapabilitiesEntry" [disabled]="disabled" queryParam="entryEditor4"></navigable-entry-editor>
+<navigable-entry-editor [entry]="tcpDriverSampleEntry()" [disabled]="disabled()" queryParam="entryEditor3"></navigable-entry-editor>
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="assemblyCellEntry" [disabled]="disabled" queryParam="entryEditor5"></navigable-entry-editor>
+<navigable-entry-editor [entry]="acquiredCapabilitiesEntry()" [disabled]="disabled()" queryParam="entryEditor4"></navigable-entry-editor>
+<mat-divider></mat-divider>
+
+<navigable-entry-editor [entry]="assemblyCellEntry()" [disabled]="disabled()" queryParam="entryEditor5"></navigable-entry-editor>
 <div class="button-area">
     <button mat-flat-button color="primary" (click)="onToggle()">Toggle Disable</button>
+    <button mat-flat-button color="primary" (click)="replaceEntry()">Replace First Entry</button>
 </div>

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.scss
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.scss
@@ -20,4 +20,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
+    gap: 16px;
 }

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
@@ -1,5 +1,6 @@
 
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { Entry, EntryUnitType, EntryValueType, NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
@@ -11,9 +12,9 @@ import { Entry, EntryUnitType, EntryValueType, NavigableEntryEditor } from '@mor
   standalone: true,
   imports: [NavigableEntryEditor, MatDivider, MatButtonModule]
 })
-export class EntryEditorDemo implements OnInit {
-  disabled = false;
-  testEntry: Entry = {
+export class EntryEditorDemo {
+  disabled = signal(false);
+  testEntry = signal<Entry>({
     displayName: 'Test Entry',
     description: 'This is the description of a test entry',
     identifier: 'RootEntry',
@@ -91,7 +92,7 @@ export class EntryEditorDemo implements OnInit {
         },
       },
       {
-        // Number
+        // Single
         displayName: 'Type Single Number Name',
         description: 'This is a Test Single description.',
         identifier: 'Single Identifier',
@@ -116,20 +117,6 @@ export class EntryEditorDemo implements OnInit {
           isReadOnly: false,
           possible: undefined,
           type: EntryValueType.Double,
-          unitType: EntryUnitType.None,
-        },
-      },
-      {
-        // Single
-        displayName: 'Type Single number Name',
-        description: 'This is a Test Single description.',
-        identifier: 'Single Identifier',
-        value: {
-          current: undefined,
-          default: undefined,
-          isReadOnly: false,
-          possible: undefined,
-          type: EntryValueType.Single,
           unitType: EntryUnitType.None,
         },
       },
@@ -332,24 +319,6 @@ export class EntryEditorDemo implements OnInit {
         },
       },
       {
-        // Flag Enum
-        displayName: 'Test Disabled Flag Enum Name',
-        description: 'This is a Disabled Test Flag Enum description.',
-        identifier: 'Disabled Flag Enum Identifier',
-        value: {
-          current: 'Option1Key, Option3Key',
-          default: '',
-          isReadOnly: false,
-          possible: [
-            { 'key': 'Option1Key', 'displayName': 'Option 1' },
-            { 'key': 'Option2Key', 'displayName': 'Option 2' },
-            { 'key': 'Option3Key', 'displayName': 'Option 3' }
-          ],
-          type: EntryValueType.Enum,
-          unitType: EntryUnitType.Flags,
-        },
-      },
-      {
         // File
         displayName: 'Test File Name',
         description: 'This is a Test File description.',
@@ -392,9 +361,9 @@ export class EntryEditorDemo implements OnInit {
         },
         subEntries: [
           {
-            displayName: 'Test List Entry',
-            description: 'Test List Description',
-            identifier: 'List Entry 1',
+            displayName: 'Test Sub-Entry String Property ',
+            description: 'Test Sub-Entry String Property Description',
+            identifier: 'Test Sub-Entry String Property 1',
             value: {
               current: '',
               default: '',
@@ -403,14 +372,17 @@ export class EntryEditorDemo implements OnInit {
           },
           {
             // Object
-            displayName: 'Subentry Object Name',
-            description: 'This is a Subentry Object description.',
+            displayName: 'Test Sub-Entry Object Property',
+            description: 'Test Sub-Entry Object Property Description.',
             identifier: 'SubSubentryObjectIdentifier',
             value: {
               current: undefined,
               default: undefined,
-              isReadOnly: true,
-              possible: undefined,
+              isReadOnly: false,
+              possible: [
+                { key: "Possible Type 1", displayName: "Displayed Possible Type 1" },
+                { key: "Possible Type 2", displayName: "Displayed Possible Type 2" }
+              ],
               type: EntryValueType.Class,
               unitType: EntryUnitType.None,
             },
@@ -602,9 +574,9 @@ export class EntryEditorDemo implements OnInit {
       },
     ],
     value: {},
-  };
+  });
 
-  tcpDriverSampleEntry: Entry = {
+  tcpDriverSampleEntry = signal<Entry>({
     "displayName": "TcpDriverSample",
     "identifier": "TcpDriverSample",
     "description": null,
@@ -1129,9 +1101,9 @@ export class EntryEditorDemo implements OnInit {
       }
     ],
     "prototypes": []
-  }
+  });
 
-  acquiredCapabilitiesEntry: Entry = {
+  acquiredCapabilitiesEntry = signal<Entry>({
     "displayName": "AcquiredCapabilities",
     "identifier": "AcquiredCapabilities",
     "description": null,
@@ -1307,9 +1279,9 @@ export class EntryEditorDemo implements OnInit {
         "prototypes": []
       }
     ]
-  }
+  });
 
-  assemblyCellEntry: Entry = {
+  assemblyCellEntry = signal<Entry>({
     "displayName": "AssemblyCell",
     "identifier": "AssemblyCell",
     "description": null,
@@ -1520,12 +1492,18 @@ export class EntryEditorDemo implements OnInit {
       }
     ],
     "prototypes": []
-  }
-  ngOnInit(): void {
-
-  }
+  });
 
   onToggle() {
-    this.disabled = !this.disabled;
+    this.disabled.update(current => !current);
+  }
+
+  replaceEntry() {
+    this.testEntry.set(this.assemblyCellEntry());
+  }
+
+  onEntryChange($event: Entry) {
+    console.log('Entry changed:', $event);
+    this.testEntry.set($event);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -21,9 +21,9 @@ export class BooleanEditor {
   entry = model.required<Entry>();
 
   constructor() {
-    const reference = effect(() => {
+    // Todo: Replace effect with computed
+    effect(() => {
       this.initialize(this.entry());
-      reference.destroy();
     });
   }
 

--- a/projects/ngx-web-framework/entry-editor/entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.html
@@ -1,8 +1,8 @@
-@if (EntryValueType.Collection === entry().value?.type) {
+@if (EntryValueType.Collection === entry().value.type) {
   <div class="entry-editor-add-list-item">
     <mat-form-field class="entry-editor-add-list-item-type-selector" appearance="outline">
       <mat-label>Select the type of object</mat-label>
-
+      <!-- Check for missing readonly integration for disabled fields and create combined/computed field -->
       <mat-select [(ngModel)]="selectedListItemType" [disabled]="disabled()">
         @for (pv of possibleListItemTypes(); track pv.key) {
           <mat-option [value]="pv.key">
@@ -24,6 +24,7 @@
   </div>
 }
 
+<!-- ToDo: Clarify whether this is only intended for prototype related selections, it is also shown if no prototype exists -->
 @if (isEntryTypeSettable(entry())) {
   <div class="settable-dropdown-entry">
     <mat-form-field appearance="outline" class="settable-dropdown-entry-selector">
@@ -33,7 +34,7 @@
         [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
         [(ngModel)]="entry().value.current"
         (selectionChange)="dropdownSelectionChanged($event)">
-        @for (pv of entry().value?.possible; track pv.key) {
+        @for (pv of entry().value.possible; track pv.key) {
           <mat-option [value]="pv.key">
             {{ pv.displayName ?? pv.key }}
           </mat-option>
@@ -51,18 +52,21 @@
 @if (entry().subEntries?.length) {
   <mat-list class="entry-editor-subentries-list">
     @for (subEntry of entry().subEntries; track subEntry.identifier) {
-      @if (EntryValueType.Collection === entry().value?.type) {
+      <!-- ToDo: Use switch on type -->
+      @if (EntryValueType.Collection === entry().value.type) {
+        <!-- ToDo: Add error message to indicate missing editor id in using application -->
         @if (editorId()) {
           <entry-list-item
             matLine
             class="entry-editor-subentries-list-item"
             [editorId]="editorId()!"
             [entry]="subEntry"
+            (entryChange)="updateSubEntry($event)"
             [disabled]="disabled()"
             (deleteRequest)="onDeleteListItem($event)">
           </entry-list-item>
         }
-      } @else if (EntryValueType.Stream === subEntry.value?.type) {
+      } @else if (EntryValueType.Stream === subEntry.value.type) {
         <entry-file-editor
           matLine
           class="entry-editor-subentries-list-item"
@@ -70,7 +74,8 @@
           (entryChange)="updateSubEntry($event)"
           [disabled]="disabled()">
         </entry-file-editor>
-      } @else if (EntryValueType.Class === subEntry.value?.type || EntryValueType.Collection === subEntry.value?.type) {
+      } @else if (EntryValueType.Class === subEntry.value.type || EntryValueType.Collection === subEntry.value.type) {
+        <!-- ToDo: Add error message to indicate missing editor id in using application -->
         @if (editorId()) {
           <entry-object-editor
             matLine
@@ -80,7 +85,7 @@
             [disabled]="disabled()">
           </entry-object-editor>
         }
-      } @else if (EntryValueType.Boolean === subEntry.value?.type) {
+      } @else if (EntryValueType.Boolean === subEntry.value.type) {
         <entry-boolean-editor
           matLine
           class="entry-editor-subentries-list-item"
@@ -88,9 +93,9 @@
           (entryChange)="updateSubEntry($event)"
           [disabled]="disabled()">
         </entry-boolean-editor>
-      } @else if (EntryValueType.Enum === subEntry.value?.type ||
-                  ((subEntry.value?.possible?.length ?? 0) > 1 &&
-                   subEntry.value?.type !== EntryValueType.Collection &&
+        <!-- ToDo remove isEntryTypeSettable call, which is for class drop downs which are handled elsewhere -->
+      } @else if (EntryValueType.Enum === subEntry.value.type ||
+                  ((subEntry.value.possible?.length ?? 0) > 1 &&
                    !isEntryTypeSettable(subEntry))) {
         <entry-enum-editor
           matLine
@@ -103,6 +108,7 @@
         <entry-input-editor
           matLine
           class="entry-editor-subentries-list-item"
+      }
           [entry]="subEntry"
           (entryChange)="updateSubEntry($event)"
           [disabled]="disabled()">

--- a/projects/ngx-web-framework/entry-editor/entry-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.scss
@@ -12,6 +12,7 @@
   flex-flow: column nowrap;
   justify-content: flex-start;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .entry-editor-subentries-list-item {

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -58,6 +58,7 @@ export class EntryEditor {
   private createdCounter?: number;
 
   constructor() {
+    // ToDo: Replace effect and signals with computed
     effect(() => {
       if(this.currentEntry !== this.entry() ){
         this.initialize(this.entry());
@@ -76,24 +77,34 @@ export class EntryEditor {
     }
   }
 
+  // Value change violates immutability requirement of signals. This is to currently circumvented by
+  // - using map on the array an creating a new array reference
+  // - creating a new entry object with the updated value and replacing the old in the mapping
+  // - propagating this reference change upwards in the array
+  // ToDo: In future a 'ReactiveEntry' wrapper would improve performance and reduce reference copying effort
   updateSubEntry(subEntry: Entry) {
     this.entry.update(item => {
       const match = item.subEntries?.find(x => x.identifier === subEntry.identifier);
-      if (match)
-        Object.assign(match, subEntry);
-      else
-        item.subEntries?.push(subEntry);
-      return item;
+      if (!match)
+        throw new Error('Failed to find sub entry with identifier ' + subEntry.identifier + ' to mutate its value');
+
+      const updatedMatch = { ...match, value: subEntry.value };
+      const updatedSubEntries = item.subEntries!.map(se =>
+        se.identifier === subEntry.identifier ? updatedMatch : se
+      );
+      const updatedEntry = { ...item, subEntries: updatedSubEntries };
+      return updatedEntry;
     });
   }
 
+  // ToDo: Move to correct place
   EntryValueType = EntryValueType;
   EntryUnitType = EntryUnitType;
 
   onDeleteListItem(toBeDeleted: Entry) {
     const entry = this.entry();
 
-    if (entry.subEntries !== undefined && entry.subEntries !== null) {
+    if (entry.subEntries) {
       var index = entry.subEntries.findIndex(c => c.identifier === toBeDeleted.identifier);
       if (index > -1) {
         entry.subEntries.splice(index, 1);
@@ -105,11 +116,13 @@ export class EntryEditor {
   addItemToList() {
     const prototypes = this.prototypes();
 
+    // ToDo: Clean up function
     if (this.selectedListItemType() && prototypes) {
       for (var i = 0; i < prototypes.length; i++) {
         if (prototypes[i].value.type == EntryValueType.Class) {
           var prototype = prototypes.find(x => x.identifier === this.selectedListItemType());
         } else {
+          // ToDo: Check why this branch is necessary identifier should always be set for prototypes
           var prototype = prototypes.find(x => x.displayName === this.selectedListItemType());
         }
       }
@@ -124,9 +137,11 @@ export class EntryEditor {
         } else {
           this.createdCounter = 1;
         }
+        // ToDo: Add default value to created counter
         if (this.createdCounter) {
           entry.identifier = 'CREATED' + this.createdCounter;
           currentEntry.subEntries?.push(entry);
+          // ToDo: Use set
           this.entry.update(_ => currentEntry);
         }
       }
@@ -158,6 +173,7 @@ export class EntryEditor {
     });
   }
 
+  // ToDo: Remove unnecessary wrapper function
   dropdownSelectionChanged(event: MatSelectChange){
     this.onPatchToSelectedEntryType(event.value);
   }

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
@@ -1,45 +1,51 @@
 <div class="full-width-input">
   <div class="entry-list-item-content">
-    @if (EntryValueType.Stream === entry().value?.type) {
+    <!-- ToDo: Use switch case & Check for missing signal updates -->
+    @if (EntryValueType.Stream === entry().value.type) {
       <entry-file-editor
         matLine
         class="entry-list-item-value"
         [entry]="entry()"
+        (entryChange)="entry.set($event)"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Class === entry().value?.type || EntryValueType.Collection === entry().value?.type) {
+    } @else if (EntryValueType.Class === entry().value.type || EntryValueType.Collection === entry().value.type) {
       <entry-object-editor
         matLine
         class="entry-list-item-value"
         [entry]="entry()"
         [editorId]="editorId()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Boolean === entry().value?.type) {
+    } @else if (EntryValueType.Boolean === entry().value.type) {
       <entry-boolean-editor
         matLine
         class="entry-list-item-value"
         [entry]="entry()"
+        (entryChange)="entry.set($event)"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Enum === entry().value?.type) {
+    } @else if (EntryValueType.Enum === entry().value.type) {
       <entry-enum-editor
         matLine
         class="entry-list-item-value"
         [entry]="entry()"
+        (entryChange)="entry.set($event)"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Byte === entry().value?.type ||
-                EntryValueType.Int16 === entry().value?.type ||
-                EntryValueType.UInt16 === entry().value?.type ||
-                EntryValueType.Int32 === entry().value?.type ||
-                EntryValueType.UInt32 === entry().value?.type ||
-                EntryValueType.Int64 === entry().value?.type ||
-                EntryValueType.UInt64 === entry().value?.type ||
-                EntryValueType.Single === entry().value?.type ||
-                EntryValueType.Double === entry().value?.type ||
-                EntryValueType.String === entry().value?.type ||
-                EntryValueType.Exception === entry().value?.type) {
+    } @else if (EntryValueType.Byte === entry().value.type ||
+                EntryValueType.Int16 === entry().value.type ||
+                EntryValueType.UInt16 === entry().value.type ||
+                EntryValueType.Int32 === entry().value.type ||
+                EntryValueType.UInt32 === entry().value.type ||
+                EntryValueType.Int64 === entry().value.type ||
+                EntryValueType.UInt64 === entry().value.type ||
+                EntryValueType.Single === entry().value.type ||
+                EntryValueType.Double === entry().value.type ||
+                EntryValueType.String === entry().value.type ||
+                EntryValueType.Exception === entry().value.type) {
+                  <!-- ToDo: Check reuse of isprimitive type function for condition -->
       <entry-input-editor
         matLine
         class="entry-list-item-value"
         [entry]="entry()"
+        (entryChange)="entry.set($event)"
         [disabled]="disabled()" />
     }
 

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
@@ -1,12 +1,12 @@
-import { Component, computed, EventEmitter, input, Output } from '@angular/core';
+import { Component, EventEmitter, input, model, Output } from '@angular/core';
 import { Entry } from '../models/entry';
-import { EntryUnitType } from '../models/entry-unit-type';
 import { EntryValueType } from '../models/entry-value-type';
 import { FileEditor } from '../file-editor/file-editor';
 import { EntryObject} from '../entry-object/entry-object';
 import { BooleanEditor } from '../boolean-editor/boolean-editor';
 import { InputEditor } from '../input-editor/input-editor';
 import { EnumEditor } from '../enum-editor/enum-editor';
+// ToDo: Remove common module import
 import { CommonModule } from '@angular/common';
 import { MatLine } from '@angular/material/core';
 import { MatIconButton } from '@angular/material/button';
@@ -29,17 +29,12 @@ import { MatListModule } from '@angular/material/list';
   styleUrl: './entry-list-item.scss',
 })
 export class EntryListItem {
-  entry = input.required<Entry>();
+  entry = model.required<Entry>();
   editorId = input.required<number>();
   disabled = input<boolean>(false);
   @Output() deleteRequest: EventEmitter<Entry> = new EventEmitter<Entry>();
-  isObjectType = computed(() => {
-    return EntryValueType.Class === this.entry().value?.type || EntryValueType.Collection === this.entry().value?.type;
-  });
 
   EntryValueType = EntryValueType;
-  EntryUnitType = EntryUnitType;
-  constructor() {}
 
   onDelete() {
     this.deleteRequest.emit(this.entry());

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
@@ -6,6 +6,7 @@
     </div>
   </button>
 
+  <!-- ToDo: If empty the space collapses leaving not enough of a gap to following entries -->
   <div class="object-entry-hint" [class.entry-editor-disabled]="disabled() || (entry().value.isReadOnly ?? false)">
     {{ entry().description }}
   </div>

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
@@ -8,6 +8,7 @@
       </mat-option>
     }
   </mat-select>
+  <!-- ToDo: Check truncate class not working -->
   <mat-hint [ngClass]="{'entry-editor-disabled': (disabled() || (entry().value.isReadOnly ?? false))}" class="truncate">
     {{entry().description}}
   </mat-hint>

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
@@ -43,6 +43,7 @@
   <mat-form-field class="full-width-input entry-form-field" appearance="outline">
     <mat-label>{{ entry().displayName }}</mat-label>
     @if (!useTextArea()) {
+      <!--  ToDo: Cleanup placeholder -->
       <input
         aria-label="Text field for changing an entry value."
         [type]="isPassword ? 'password' : isNumber ? 'number' : 'text'"

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
@@ -1,4 +1,4 @@
-import { Component, effect, input, model, OnDestroy, signal } from '@angular/core';
+import { Component, effect, input, model, OnDestroy, signal, untracked } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl, ValidatorFn, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { Entry } from '../models/entry';
@@ -10,13 +10,13 @@ import {
   minEntryValueValidator,
 } from '../validators/entry-editor.validators';
 import { CommonModule } from '@angular/common';
-import { EntryValue } from '../models/entry-value';
 import { MatError, MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSliderModule } from '@angular/material/slider';
 
+// ToDo: Format file
 @Component({
   selector: 'entry-input-editor',
   imports: [
@@ -47,9 +47,37 @@ export class InputEditor implements OnDestroy {
 
   constructor() {
     this.inputFormControl = new UntypedFormControl();
+
+    // One-time initialization assuming a different entry (by identifier not only reference) 
+    // creates a new component instance.
     const reference = effect(() => {
       this.initialize(this.entry());
       reference.destroy();
+    });
+
+    // Entry initialization & updates on every ref change
+    effect(() => {
+      const entry = this.entry();
+      
+      untracked(() => {
+        // ToDo: Check emitEvent
+        if(this.isSinglePossibleValue(entry)){
+          const singlePossibleValue = entry.value?.possible?.[0]?.key ?? '';
+          
+          if (this.inputFormControl.value !== singlePossibleValue) {
+            this.inputFormControl.setValue(singlePossibleValue, { emitEvent: false });
+          }          
+
+          if (entry.value?.current !== singlePossibleValue) {
+            this.entry.update(e => { 
+              e.value.current = singlePossibleValue;
+              return { ...e };
+            });
+          }
+        } else if (entry.value?.current !== this.inputFormControl.value) {
+          this.inputFormControl.setValue(entry.value?.current ?? '', { emitEvent: false });
+        }
+      });
     });
 
     effect(() => {
@@ -61,23 +89,14 @@ export class InputEditor implements OnDestroy {
     this.readOnly.set(
       entry.value?.isReadOnly || this.isSinglePossibleValue(entry) || entry.value.type === EntryValueType.Exception
     );
-    this.updateCurrentValue(entry.value, entry.value.current);
+
     this.determineInputType();
 
     const validators = this.setupValidators(entry);
     this.inputFormControl = this.setupFormControl(entry, validators);
   }
 
-  private updateCurrentValue(currentValue: EntryValue, value: any) {
-    this.entry.update(e => {
-      let copy = Object.assign({}, e);
-      copy.value.current = this.isSinglePossibleValue(e)
-        ? (e.value.possible?.[0]?.key ?? '')
-        : value ?? currentValue?.default;
-      return copy;
-    });
-  }
-
+  // ToDo: Check if anything like C# out variable for function exists and use here
   isSinglePossibleValue(entry: Entry): boolean {
     const result = entry.value.possible && entry.value.possible.length === 1;
     return result ?? false;
@@ -109,7 +128,10 @@ export class InputEditor implements OnDestroy {
 
     this.formControlSubscription = result.valueChanges.subscribe(value => {
       if (result.status == 'VALID') {
-        this.updateCurrentValue(this.entry().value, value);
+        this.entry.update(e => { 
+          e.value.current = value;
+          return { ...e };
+        });
       }
     });
 

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
@@ -1,9 +1,10 @@
 @if(entryInformation(); as entryInfo) {
   @if (entryInfo.entryPath) {
     <div class="navigation-bar">
+      <!-- ToDo: Update tracking as whole collection is recreated every time -->
       @for (e of entryInfo.entryPath; track e; let isLast = $last) {
         <span class="navigation-bar-item" (click)="onNavigateSpecific(e)">
-          {{e.displayName}}
+          {{e().displayName}}
         </span>
         @if (!isLast) {
           <span class="material-symbols-outlined navigation-bar-layers navigation-bar-divider">
@@ -14,11 +15,11 @@
     </div>
   }
 
-
-  @if (entryInfo.currentEntry) {
+  @if (entryInfo.currentEntry()) {
     <entry-editor
       [editorId]="editorId()" class="navigation-entries"
-      [(entry)]="entryInfo.currentEntry"
+      [entry]="entryInfo.currentEntry()"
+      (entryChange)="onEntryChange($event)"
       [disabled]="disabled()">
     </entry-editor>
   }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy, input, effect, model, signal, untracked, inject } from '@angular/core';
+import { Component, OnDestroy, input, model, inject, computed, WritableSignal, untracked } from '@angular/core';
 import { Entry } from './models/entry';
-import { NavigableEntryInformation, NavigableEntryService } from './services/navigable-entry.service';
+import { NavigableEntryService } from './services/navigable-entry.service';
 import { EntryEditor } from './entry-editor';
 
 @Component({
@@ -12,44 +12,32 @@ import { EntryEditor } from './entry-editor';
 export class NavigableEntryEditor implements OnDestroy {
   private service = inject(NavigableEntryService);
 
+  // ToDo: Add proper comments for public inputs
   queryParam = input<string | undefined>(undefined);
   disabled = input.required<boolean>();
-  //id of the navigableEditor in order to be able to use several entry editors at the same time
-  editorId = signal<number>(0);
 
   entry = model.required<Entry>();
 
-  entryInformation = signal<NavigableEntryInformation | undefined>(undefined);
+  //id of the navigableEditor in order to be able to use several entry editors at the same time
+  editorId = computed(() => {
+    const queryParam = this.queryParam();
+    return untracked(() => this.service.signIn(this.entry, queryParam));
+  });
 
-  constructor() {
-    effect(() => {
-      // `this.entry()` is assigned to `entry` to make sure,
-      // updates on it will be tracked and take 'effect'.
-
-      const entry = Object.assign(this.entry());
-      untracked(() => {
-        this.update(entry, this.editorId());
-      });
-    });
-  }
-
-  private update(entry: Entry, editorId: number) {
-    if (editorId !== 0) {
-      this.service.signOut(editorId);
-    }
-    editorId = this.service.signIn(entry, this.queryParam());
-    this.editorId.set(editorId);
-    const infos = this.service.entryEditorInformation.get(editorId);
-
-    if (!infos) return;
-    this.entryInformation.set(infos);
+  entryInformation = computed(() => {
+    const editorId = this.editorId();
+    return untracked(() => this.service.entryEditorInformation.get(editorId));
+  });
+    
+  onEntryChange(entry: Entry) {
+    this.service.onEntryChange(this.editorId(), entry);
   }
 
   ngOnDestroy(): void {
     this.service.signOut(this.editorId());
   }
 
-  onNavigateSpecific(entry: Entry) {
+  onNavigateSpecific(entry: WritableSignal<Entry>) {
     this.service.onNavigateToSpecificEntry(this.editorId(), entry);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/services/navigable-entry.service.ts
+++ b/projects/ngx-web-framework/entry-editor/services/navigable-entry.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { effect, EffectRef, EnvironmentInjector, inject, Injectable, runInInjectionContext, signal, untracked, WritableSignal } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Entry } from '../models/entry';
 
@@ -8,6 +8,7 @@ import { Entry } from '../models/entry';
 export class NavigableEntryService {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+  private reactiveEnvironment = inject(EnvironmentInjector);
 
   public entryEditorInformation: Map<number, NavigableEntryInformation> =
     new Map<number, NavigableEntryInformation>();
@@ -21,19 +22,26 @@ export class NavigableEntryService {
    * @param queryParam optional. In here the entry path can be saved
    * @returns unique id in order to identify the navigable entry editor
    */
-  signIn(entry: Entry, queryParam: string | undefined = undefined): number {
-    this.biggestEditorId++;
+  signIn(entry: WritableSignal<Entry>, queryParam: string | undefined = undefined): number {
+    
+    const editorId = ++this.biggestEditorId;
+
+    // ToDo: Search for usings of 'var' instead of let or const
+    // ToDo: Why are these two seperate types?
     var information = <NavigableEntryInformation>{
-      entryPath: [] as Entry[],
+      entryPath: [entry],
       currentEntry: entry,
     };
+
+    const entryUpdateEffect = runInInjectionContext(this.reactiveEnvironment, () => this.createUpdateEffect(entry, editorId));
+
     var parameters = <NavigableEntryParameters>{
       baseEntry: entry,
       queryParam: queryParam,
+      updateEffect: entryUpdateEffect
     };
-    information.entryPath.push(entry);
-    this.entryEditorParameters.set(this.biggestEditorId, parameters);
-    this.entryEditorInformation.set(this.biggestEditorId, information);
+    this.entryEditorParameters.set(editorId, parameters);
+    this.entryEditorInformation.set(editorId, information);
 
     if (queryParam)
       this.setNavigableEntryInformationAccordingToQueryParam(
@@ -41,7 +49,51 @@ export class NavigableEntryService {
         parameters
       );
 
-    return this.biggestEditorId;
+    return editorId;
+  }
+
+  private createUpdateEffect(entry: WritableSignal<Entry>, editorId: number): EffectRef {
+    return effect(() => {
+      const rootEntry = entry();
+      const information = this.entryEditorInformation.get(editorId);
+      if (!information) {
+        throw new Error(`Failed to propagate entry change: No entry information found for editor ${this.biggestEditorId}`);
+      }
+
+      untracked(() => this.propagateIncomingEntryChange(rootEntry, information));
+    });
+  }
+
+  /**
+   * If the root entry changes this can either be the result of an outgoing change or an incoming change. In 
+   * the case of an incoming change the navigable entry editor needs to be updated with the new entry data. 
+   * This method recursively propagates the incoming change down to the stored signals for the path of sub-entries
+   * in the NavigableEntryInformation.
+  */
+  private propagateIncomingEntryChange(updatedEntry: Entry, information: NavigableEntryInformation, index: number = 1) {
+    if (index >= information.entryPath.length) {
+      // We reached the end of the entry path
+      return;
+    }
+
+    const entryToUpdate = information.entryPath[index];
+    if (updatedEntry.subEntries?.find(se => Object.is(se, entryToUpdate()))) {
+      // Break recursion, as the signal is already up to date or the update is not in the remaining, opened branch
+      // (i.e. the signal already contains a matching entry reference)
+      return;
+    }
+
+    const replacementSubEntry = updatedEntry.subEntries?.find(se => se.identifier === entryToUpdate().identifier);
+    if (!replacementSubEntry) {
+      // Break recursion, trim remaining, opened branch, reset current entry and adjust query params, 
+      // as the updated entry does not contain a matching sub-entry anymore
+      information.entryPath = information.entryPath.slice(0, index);
+      information.currentEntry.set(information.entryPath[information.entryPath.length - 1]());
+      // ToDo: Adjust query params according to new entry path
+      return;
+    }
+    entryToUpdate.set(replacementSubEntry);
+    this.propagateIncomingEntryChange(replacementSubEntry, information, index + 1);
   }
 
   /**
@@ -50,8 +102,6 @@ export class NavigableEntryService {
    * @param editorId unique id of the service
    */
   signOut(editorId: number) {
-    if (!this.entryEditorInformation.has(editorId)) return;
-
     const infos = this.entryEditorInformation.get(editorId);
     if (!infos) return;
 
@@ -61,6 +111,7 @@ export class NavigableEntryService {
     if (parameters.queryParam) {
       this.updateQuery({ [parameters.queryParam]: null });
     }
+    parameters.updateEffect.destroy();
     this.entryEditorInformation.delete(editorId);
     this.entryEditorParameters.delete(editorId);
   }
@@ -77,6 +128,7 @@ export class NavigableEntryService {
     if (!parameters.queryParam) return;
     if (!parameters.baseEntry) return;
 
+    // ToDo: make async/await
     const queryParamSubsrciption = this.route.queryParams.subscribe(
       (queryParams) => {
         if (!parameters.queryParam) return;
@@ -105,7 +157,7 @@ export class NavigableEntryService {
   }
 
   private createNavigableEntryInformationAccordingToQueryParam(
-    baseEntry: Entry,
+    baseEntry: WritableSignal<Entry>,
     queryParamName: string,
     queryParams: Params
   ): NavigableEntryInformation | undefined {
@@ -116,8 +168,7 @@ export class NavigableEntryService {
     let entries = queryParamValue.split('.');
     if (entries === undefined) return undefined;
 
-    const entryPath = [] as Entry[];
-    entryPath.push(baseEntry);
+    const entryPath = [baseEntry];
 
     const newInformation = <NavigableEntryInformation>{
       currentEntry: entry,
@@ -125,14 +176,15 @@ export class NavigableEntryService {
     }
 
     for (let entryIdentifier of entries) {
-      if (entryIdentifier === entry.identifier) continue;
+      if (entryIdentifier === entry().identifier) continue;
 
-      var subEntry = entry.subEntries?.find(
+      var subEntry = entry().subEntries?.find(
         (x) => x.identifier === entryIdentifier
       );
       if (subEntry !== undefined) {
-        entryPath.push(subEntry);
-        entry = subEntry;
+        const subEntrySignal = signal(subEntry);
+        entryPath.push(subEntrySignal);
+        entry = subEntrySignal;
       } else {
         this.setQueryParam(newInformation, queryParamName);
         break;
@@ -149,7 +201,7 @@ export class NavigableEntryService {
    * @param entry the entry the user wants to navigate to
    * @returns
    */
-  onNavigateToSpecificEntry(editorId: number, entry: Entry) {
+  onNavigateToSpecificEntry(editorId: number, entry: WritableSignal<Entry>) {
     if (!this.entryEditorInformation.has(editorId)) return;
 
     const infos = this.entryEditorInformation.get(editorId);
@@ -180,8 +232,9 @@ export class NavigableEntryService {
     const parameters = this.entryEditorParameters.get(editorId);
     if (!parameters) return;
 
-    infos.entryPath.push(newEntry);
-    infos.currentEntry = newEntry;
+    const entrySignal = signal(newEntry);
+    infos.entryPath.push(entrySignal);
+    infos.currentEntry = entrySignal;
     if (parameters.queryParam)
       this.setQueryParam(infos, parameters.queryParam);
   }
@@ -193,7 +246,7 @@ export class NavigableEntryService {
     if (!queryParamName) return;
     let path = '';
     for (var e of information.entryPath) {
-      path = path + e.identifier + '.';
+      path = path + e().identifier + '.';
     }
     path = path.substring(0, path.length - 1);
     this.updateQuery({ [queryParamName]: path });
@@ -205,14 +258,62 @@ export class NavigableEntryService {
       queryParamsHandling: 'merge',
     });
   }
+
+  
+  /**
+   * Notify the service about a change of a (sub)entry to propagate the chance up the
+   * path of the NavigableEntryInformation for a specific signed-in editor.
+   * This will trigger an update of the root entry
+   * @param editorId The editor id of the relevant editor
+   * @param entry The sub entry which changes are to be propagated to its root.
+   */
+  onEntryChange(editorId: number, entry: Entry) {
+    const infos = this.entryEditorInformation.get(editorId);
+    if (!infos) {
+      throw new Error(`Failed to update entry ${entry.displayName}: Editor ${editorId} not signed in`);
+    }
+
+    const entryIndex = infos.entryPath.findIndex(e => e().identifier === entry.identifier);
+    if (entryIndex === -1) {
+      throw new Error(`Failed to update entry ${entry.displayName}: Entry not in path of editor ${editorId}`);
+    }
+
+    if (Object.is(infos.entryPath[entryIndex], entry)){
+      throw new Error(`Failed to update entry ${entry.displayName}: Make sure to provide a different entry reference for the update.`);
+    }
+
+    this.propagateEntryChange(infos.entryPath, entryIndex, entry);
+  }
+
+  /**
+   * Recursively propagate the (sub)entry change up the entry path up to the root entry
+   * updating the entry references as well as the subEntries array reference.
+   */
+  private propagateEntryChange(entryPath: WritableSignal<Entry>[], entryIndex: number, updatedEntry: Entry) {
+    entryPath[entryIndex].set(updatedEntry);
+    if (entryIndex === 0) return;
+
+    const parentEntryIndex = entryIndex - 1;
+    const parentEntry = entryPath[parentEntryIndex];
+    const match = parentEntry().subEntries?.find(x => x.identifier === updatedEntry.identifier);
+    if (!match)
+      throw new Error(`Failed to propagate entry change for entry ${updatedEntry.displayName}: Failed to find entry in parent entry's sub entries`);
+
+    const updatedParentEntry = <Entry>{ ...parentEntry(), subEntries: parentEntry().subEntries!.map(se =>
+      se.identifier === updatedEntry.identifier ? updatedEntry : se
+    )};
+
+    this.propagateEntryChange(entryPath, parentEntryIndex, updatedParentEntry);
+  }
 }
 
 export interface NavigableEntryInformation {
-  entryPath: Entry[];
-  currentEntry: Entry | undefined;
+  entryPath: WritableSignal<Entry>[];
+  currentEntry: WritableSignal<Entry>;
 }
 
 interface NavigableEntryParameters {
-  baseEntry: Entry | undefined;
+  baseEntry: WritableSignal<Entry>;
   queryParam: string | undefined;
+  updateEffect: EffectRef;
 }


### PR DESCRIPTION
# Summary
Adds signal infrastructure to NavigableEntryEditor

Modifies the NavigableEntryService to work based on writable signals.
Added change propagation logic for internal and external updates on the NavigableEntryService.
Removes all logic preventing external updates on subcomponents for specific entries.
Fixed issue with infinitely growing entry editor ids.

Also added many todos for future cleanup unrelated to this change

# References
Sources stating the reasons for the issues after the Angular 21 update:
- https://www.angulararchitects.io/en/blog/angular-signals/#:~:text=Signal%20Values%20Should%20to%20be,they%20keep%20their%20object%20reference.
- https://angular.dev/guide/signals#signal-equality-functions

Further readin/good to know: 
- https://angular.dev/guide/signals/linked-signal
- Best practice for array clones is to use map on existing array
- Angular optimzes @for loops if the array reference has changed, but the tracked references haven't => don't track by value of items as this causes expensive rerendering on every execution
- There is a syntax for creating model clones with only a single property changes => use as usually only the current value of entries changes