### PR TITLE
Support EntryEditor in zoneless environments

### DIFF
--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
@@ -17,6 +17,7 @@
 <navigable-entry-editor [entry]="assemblyCellEntry()" [disabled]="disabled()"
                         queryParam="entryEditor5" />
 
+
 <div class="button-area">
     <button mat-flat-button color="primary" (click)="onToggle()">Toggle Disable</button>
 </div>

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
@@ -1,16 +1,22 @@
-<navigable-entry-editor [entry]="testEntry()" [disabled]="disabled" (entryChange)="onEntryChange($event)" queryParam="entryEditor1"></navigable-entry-editor>
+<navigable-entry-editor [entry]="testEntry()" [disabled]="disabled()"
+                        (entryChange)="onEntryChange($event)" queryParam="entryEditor1" />
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="testEntry()" [disabled]="disabled" (entryChange)="onEntryChange($event)" queryParam="entryEditor2"></navigable-entry-editor>
+<navigable-entry-editor [entry]="testEntry()" [disabled]="disabled()"
+                        (entryChange)="onEntryChange($event)" queryParam="entryEditor2" />
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="tcpDriverSampleEntry()" [disabled]="disabled" queryParam="entryEditor3"></navigable-entry-editor>
+<navigable-entry-editor [entry]="tcpDriverSampleEntry()" [disabled]="disabled()"
+                        queryParam="entryEditor3" />
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="acquiredCapabilitiesEntry()" [disabled]="disabled" queryParam="entryEditor4"></navigable-entry-editor>
+<navigable-entry-editor [entry]="acquiredCapabilitiesEntry()" [disabled]="disabled()"
+                        queryParam="entryEditor4" />
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="assemblyCellEntry()" [disabled]="disabled" queryParam="entryEditor5"></navigable-entry-editor>
+<navigable-entry-editor [entry]="assemblyCellEntry()" [disabled]="disabled()"
+                        queryParam="entryEditor5" />
+
 <div class="button-area">
     <button mat-flat-button color="primary" (click)="onToggle()">Toggle Disable</button>
 </div>

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.html
@@ -1,13 +1,16 @@
-<navigable-entry-editor [entry]="testEntry" [disabled]="disabled" queryParam="entryEditor1"></navigable-entry-editor>
+<navigable-entry-editor [entry]="testEntry()" [disabled]="disabled" (entryChange)="onEntryChange($event)" queryParam="entryEditor1"></navigable-entry-editor>
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="tcpDriverSampleEntry" [disabled]="disabled" queryParam="entryEditor3"></navigable-entry-editor>
+<navigable-entry-editor [entry]="testEntry()" [disabled]="disabled" (entryChange)="onEntryChange($event)" queryParam="entryEditor2"></navigable-entry-editor>
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="acquiredCapabilitiesEntry" [disabled]="disabled" queryParam="entryEditor4"></navigable-entry-editor>
+<navigable-entry-editor [entry]="tcpDriverSampleEntry()" [disabled]="disabled" queryParam="entryEditor3"></navigable-entry-editor>
 <mat-divider></mat-divider>
 
-<navigable-entry-editor [entry]="assemblyCellEntry" [disabled]="disabled" queryParam="entryEditor5"></navigable-entry-editor>
+<navigable-entry-editor [entry]="acquiredCapabilitiesEntry()" [disabled]="disabled" queryParam="entryEditor4"></navigable-entry-editor>
+<mat-divider></mat-divider>
+
+<navigable-entry-editor [entry]="assemblyCellEntry()" [disabled]="disabled" queryParam="entryEditor5"></navigable-entry-editor>
 <div class="button-area">
     <button mat-flat-button color="primary" (click)="onToggle()">Toggle Disable</button>
 </div>

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
@@ -12,7 +12,7 @@ import { Entry, EntryUnitType, EntryValueType, NavigableEntryEditor } from '@mor
   imports: [NavigableEntryEditor, MatDivider, MatButtonModule]
 })
 export class EntryEditorDemo {
-  disabled = false;
+  disabled = signal(false);
   testEntry = signal<Entry>({
     displayName: 'Test Entry',
     description: 'This is the description of a test entry',
@@ -1523,10 +1523,11 @@ export class EntryEditorDemo {
   });
 
   onToggle() {
-    this.disabled = !this.disabled;
+    this.disabled.update((v) => !v);
   }
 
   onEntryChange($event: Entry) {
     console.log("onEntryChange", $event);
+    this.testEntry.set($event);
   }
 }

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
@@ -1,5 +1,5 @@
 
-import { Component, OnInit } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { Entry, EntryUnitType, EntryValueType, NavigableEntryEditor } from '@moryx/ngx-web-framework/entry-editor';
@@ -11,9 +11,9 @@ import { Entry, EntryUnitType, EntryValueType, NavigableEntryEditor } from '@mor
   standalone: true,
   imports: [NavigableEntryEditor, MatDivider, MatButtonModule]
 })
-export class EntryEditorDemo implements OnInit {
+export class EntryEditorDemo {
   disabled = false;
-  testEntry: Entry = {
+  testEntry = signal<Entry>({
     displayName: 'Test Entry',
     description: 'This is the description of a test entry',
     identifier: 'RootEntry',
@@ -94,7 +94,7 @@ export class EntryEditorDemo implements OnInit {
         // Number
         displayName: 'Type Single Number Name',
         description: 'This is a Test Single description.',
-        identifier: 'Single Identifier',
+        identifier: 'Single Number Name Identifier',
         value: {
           current: undefined,
           default: undefined,
@@ -123,7 +123,7 @@ export class EntryEditorDemo implements OnInit {
         // Single
         displayName: 'Type Single number Name',
         description: 'This is a Test Single description.',
-        identifier: 'Single Identifier',
+        identifier: 'Single Number Identifier',
         value: {
           current: undefined,
           default: undefined,
@@ -315,9 +315,9 @@ export class EntryEditorDemo implements OnInit {
       },
       {
         // Flag Enum
-        displayName: 'Test Disabled Flag Enum Name',
-        description: 'This is a Disabled Test Flag Enum description.',
-        identifier: 'Disabled Flag Enum Identifier',
+        displayName: 'Test Disabled Readonly Flag Enum Name',
+        description: 'This is a Disabled Readonly Test Flag Enum description.',
+        identifier: 'Disabled Readonly Flag Enum Name Identifier',
         value: {
           current: 'Option1Key, Option3Key',
           default: '',
@@ -334,8 +334,8 @@ export class EntryEditorDemo implements OnInit {
       {
         // Flag Enum
         displayName: 'Test Disabled Flag Enum Name',
-        description: 'This is a Disabled Test Flag Enum description.',
-        identifier: 'Disabled Flag Enum Identifier',
+        description: 'This is a Disabled Test Flag Enum Name description.',
+        identifier: 'Disabled Flag Enum Name Identifier',
         value: {
           current: 'Option1Key, Option3Key',
           default: '',
@@ -602,9 +602,9 @@ export class EntryEditorDemo implements OnInit {
       },
     ],
     value: {},
-  };
+  });
 
-  tcpDriverSampleEntry: Entry = {
+  tcpDriverSampleEntry = signal<Entry>({
     "displayName": "TcpDriverSample",
     "identifier": "TcpDriverSample",
     "description": null,
@@ -1129,9 +1129,9 @@ export class EntryEditorDemo implements OnInit {
       }
     ],
     "prototypes": []
-  }
+  });
 
-  acquiredCapabilitiesEntry: Entry = {
+  acquiredCapabilitiesEntry = signal<Entry>({
     "displayName": "AcquiredCapabilities",
     "identifier": "AcquiredCapabilities",
     "description": null,
@@ -1307,9 +1307,9 @@ export class EntryEditorDemo implements OnInit {
         "prototypes": []
       }
     ]
-  }
+  });
 
-  assemblyCellEntry: Entry = {
+  assemblyCellEntry = signal<Entry>({
     "displayName": "AssemblyCell",
     "identifier": "AssemblyCell",
     "description": null,
@@ -1520,12 +1520,13 @@ export class EntryEditorDemo implements OnInit {
       }
     ],
     "prototypes": []
-  }
-  ngOnInit(): void {
-
-  }
+  });
 
   onToggle() {
     this.disabled = !this.disabled;
+  }
+
+  onEntryChange($event: Entry) {
+    console.log("onEntryChange", $event);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
@@ -2,16 +2,16 @@
   <mat-checkbox
     (click)="clickContainer($event)"
     [checked]="checked()"
-    [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-    [name]="name()"
+    [disabled]="disabled() || (reactiveEntry().value.isReadOnly ?? false)"
+    [name]="reactiveEntry().displayName ?? ''"
     color="primary">
     <div class="checkbox-text-area">
-      {{ name() }}
-      @if (description()) {
+      {{ reactiveEntry().displayName }}
+      @if (reactiveEntry().description) {
         <mat-hint
           class="boolean-entry-form-hint"
-          [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }">
-          {{ description() }}
+          [ngClass]="{ 'entry-editor-disabled': disabled() || (reactiveEntry().value.isReadOnly ?? false) }">
+          {{ reactiveEntry().description }}
         </mat-hint>
       }
     </div>

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -1,5 +1,5 @@
-import { Component, effect, input, model, signal, ViewEncapsulation } from '@angular/core';
-import { Entry } from '../models/entry';
+import { Component, effect, input, signal, ViewEncapsulation } from '@angular/core';
+import { ReactiveEntry } from '../reactive-entry';
 import { MatHint } from '@angular/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
@@ -14,40 +14,34 @@ import { CommonModule, NgClass } from '@angular/common';
 })
 export class BooleanEditor {
   checked = signal<boolean>(false);
-  name = signal<string>('');
-  description = signal<string>('');
 
   disabled = input<boolean>(false);
-  entry = model.required<Entry>();
+  reactiveEntry = input.required<ReactiveEntry>();
 
   constructor() {
     const reference = effect(() => {
-      this.initialize(this.entry());
+      this.initialize(this.reactiveEntry());
       reference.destroy();
     });
   }
 
-  private initialize(entry: Entry) {
+  private initialize(re: ReactiveEntry) {
+    const entry = re.entry();
     const defaultChecked =
       (entry.value?.current ?? entry.value?.default)?.localeCompare('true', undefined, {
         sensitivity: 'base',
       }) === 0;
     this.checked.set(defaultChecked);
-    this.description.set(entry.description ?? '');
-    this.name.set(this.entry().displayName ?? '');
   }
 
   checkedUpdated(value: boolean) {
     this.checked.update(e => !e);
-    this.entry.update(e => {
-      let copy = Object.assign({}, e);
-      copy.value.current = this.checked() + '';
-      return copy;
-    });
+    this.reactiveEntry().setCurrent(this.checked() + '');
   }
 
   clickContainer(event: MouseEvent) {
-    if (!this.disabled()) {
+    const re = this.reactiveEntry();
+    if (!this.disabled() && !re.value?.isReadOnly) {
       this.checkedUpdated(!this.checked());
     }
   }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -13,10 +13,10 @@ import { CommonModule, NgClass } from '@angular/common';
   imports: [CommonModule, MatHint, MatCheckbox, FormsModule, NgClass],
 })
 export class BooleanEditor {
-  checked = signal<boolean>(false);
-
   disabled = input<boolean>(false);
   reactiveEntry = input.required<ReactiveEntry>();
+
+  checked = signal<boolean>(false);
 
   constructor() {
     const reference = effect(() => {
@@ -25,10 +25,9 @@ export class BooleanEditor {
     });
   }
 
-  private initialize(re: ReactiveEntry) {
-    const entry = re.entry();
+  private initialize(reactiveEntry: ReactiveEntry) {
     const defaultChecked =
-      (entry.value?.current ?? entry.value?.default)?.localeCompare('true', undefined, {
+      (reactiveEntry.currentValue() ?? reactiveEntry.value.default)?.localeCompare('true', undefined, {
         sensitivity: 'base',
       }) === 0;
     this.checked.set(defaultChecked);
@@ -36,12 +35,11 @@ export class BooleanEditor {
 
   checkedUpdated(value: boolean) {
     this.checked.update(e => !e);
-    this.reactiveEntry().setCurrent(this.checked() + '');
+    this.reactiveEntry().setCurrentValue(this.checked() + '');
   }
 
   clickContainer(event: MouseEvent) {
-    const re = this.reactiveEntry();
-    if (!this.disabled() && !re.value?.isReadOnly) {
+    if (!this.disabled() && !this.reactiveEntry().value.isReadOnly) {
       this.checkedUpdated(!this.checked());
     }
   }

--- a/projects/ngx-web-framework/entry-editor/entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.html
@@ -32,7 +32,7 @@
 
         <mat-select
           [disabled]="disabled() || (entry.value.isReadOnly ?? false)"
-          [ngModel]="entry.current()"
+          [ngModel]="entry.currentValue()"
           (selectionChange)="dropdownSelectionChanged($event)">
           @for (pv of entry.value?.possible; track pv.key) {
             <mat-option [value]="pv.key">
@@ -70,7 +70,7 @@
             [reactiveEntry]="subEntry"
             [disabled]="disabled()">
           </entry-file-editor>
-        } @else if (EntryValueType.Class === subEntry.value?.type || EntryValueType.Collection === subEntry.value?.type) {
+        } @else if (subEntry.value.type === EntryValueType.Class || subEntry.value.type === EntryValueType.Collection) {
           @if (editorId()) {
             <entry-object-editor
               matLine
@@ -80,16 +80,16 @@
               [disabled]="disabled()">
             </entry-object-editor>
           }
-        } @else if (EntryValueType.Boolean === subEntry.value?.type) {
+        } @else if (subEntry.value?.type === EntryValueType.Boolean) {
           <entry-boolean-editor
             matLine
             class="entry-editor-subentries-list-item"
             [reactiveEntry]="subEntry"
             [disabled]="disabled()">
           </entry-boolean-editor>
-        } @else if (EntryValueType.Enum === subEntry.value?.type ||
-                    ((subEntry.value?.possible?.length ?? 0) > 1 &&
-                     subEntry.value?.type !== EntryValueType.Collection &&
+        } @else if (subEntry.value.type === EntryValueType.Enum ||
+                    ((subEntry.value.possible?.length ?? 0) > 1 &&
+                     subEntry.value.type !== EntryValueType.Collection &&
                      !isEntryTypeSettable(subEntry))) {
           <entry-enum-editor
             matLine

--- a/projects/ngx-web-framework/entry-editor/entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.html
@@ -1,113 +1,111 @@
-@if (EntryValueType.Collection === entry().value?.type) {
-  <div class="entry-editor-add-list-item">
-    <mat-form-field class="entry-editor-add-list-item-type-selector" appearance="outline">
-      <mat-label>Select the type of object</mat-label>
+@if (re; as entry) {
+  @if (EntryValueType.Collection === entry.value?.type) {
+    <div class="entry-editor-add-list-item">
+      <mat-form-field class="entry-editor-add-list-item-type-selector" appearance="outline">
+        <mat-label>Select the type of object</mat-label>
 
-      <mat-select [(ngModel)]="selectedListItemType" [disabled]="disabled()">
-        @for (pv of possibleListItemTypes(); track pv.key) {
-          <mat-option [value]="pv.key">
-            {{ pv.displayName ?? pv.key }}
-          </mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
+        <mat-select [(ngModel)]="selectedListItemType" [disabled]="disabled()">
+          @for (pv of possibleListItemTypes(); track pv.key) {
+            <mat-option [value]="pv.key">
+              {{ pv.displayName ?? pv.key }}
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
 
-    <button
-      mat-icon-button
-      class="entry-editor-add-list-item-button"
-      type="button"
-      (click)="addItemToList()"
-      [disabled]="disabled()"
-      [ngClass]="{ disabled: disabled() }">
-      <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_add</span>
-    </button>
-  </div>
-}
+      <button
+        mat-icon-button
+        class="entry-editor-add-list-item-button"
+        type="button"
+        (click)="addItemToList()"
+        [disabled]="disabled()"
+        [ngClass]="{ disabled: disabled() }">
+        <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_add</span>
+      </button>
+    </div>
+  }
 
-@if (isEntryTypeSettable(entry())) {
-  <div class="settable-dropdown-entry">
-    <mat-form-field appearance="outline" class="settable-dropdown-entry-selector">
-      <mat-label>{{ entry().displayName }}</mat-label>
+  @if (isEntryTypeSettable(entry)) {
+    <div class="settable-dropdown-entry">
+      <mat-form-field appearance="outline" class="settable-dropdown-entry-selector">
+        <mat-label>{{ entry.displayName }}</mat-label>
 
-      <mat-select
-        [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-        [(ngModel)]="entry().value.current"
-        (selectionChange)="dropdownSelectionChanged($event)">
-        @for (pv of entry().value?.possible; track pv.key) {
-          <mat-option [value]="pv.key">
-            {{ pv.displayName ?? pv.key }}
-          </mat-option>
-        }
-      </mat-select>
-      <mat-hint
-        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
-        class="truncate">
-        {{ entry().description }}
-      </mat-hint>
-    </mat-form-field>
-  </div>
-}
+        <mat-select
+          [disabled]="disabled() || (entry.value.isReadOnly ?? false)"
+          [ngModel]="entry.current()"
+          (selectionChange)="dropdownSelectionChanged($event)">
+          @for (pv of entry.value?.possible; track pv.key) {
+            <mat-option [value]="pv.key">
+              {{ pv.displayName ?? pv.key }}
+            </mat-option>
+          }
+        </mat-select>
+        <mat-hint
+          [ngClass]="{ 'entry-editor-disabled': disabled() || (entry.value.isReadOnly ?? false) }"
+          class="truncate">
+          {{ entry.description }}
+        </mat-hint>
+      </mat-form-field>
+    </div>
+  }
 
-@if (entry().subEntries?.length) {
-  <mat-list class="entry-editor-subentries-list">
-    @for (subEntry of entry().subEntries; track subEntry.identifier) {
-      @if (EntryValueType.Collection === entry().value?.type) {
-        @if (editorId()) {
-          <entry-list-item
+  @if (entry.subEntries().length) {
+    <mat-list class="entry-editor-subentries-list">
+      @for (subEntry of entry.subEntries(); track subEntry.identifier) {
+        @if (EntryValueType.Collection === entry.value?.type) {
+          @if (editorId()) {
+            <entry-list-item
+              matLine
+              class="entry-editor-subentries-list-item"
+              [editorId]="editorId()!"
+              [reactiveEntry]="subEntry"
+              [disabled]="disabled()"
+              (deleteRequest)="onDeleteListItem($event)">
+            </entry-list-item>
+          }
+        } @else if (EntryValueType.Stream === subEntry.value?.type) {
+          <entry-file-editor
             matLine
             class="entry-editor-subentries-list-item"
-            [editorId]="editorId()!"
-            [entry]="subEntry"
-            [disabled]="disabled()"
-            (deleteRequest)="onDeleteListItem($event)">
-          </entry-list-item>
-        }
-      } @else if (EntryValueType.Stream === subEntry.value?.type) {
-        <entry-file-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
-        </entry-file-editor>
-      } @else if (EntryValueType.Class === subEntry.value?.type || EntryValueType.Collection === subEntry.value?.type) {
-        @if (editorId()) {
-          <entry-object-editor
-            matLine
-            class="entry-editor-subentries-list-item"
-            [entry]="subEntry"
-            [editorId]="editorId()!"
+            [reactiveEntry]="subEntry"
             [disabled]="disabled()">
-          </entry-object-editor>
+          </entry-file-editor>
+        } @else if (EntryValueType.Class === subEntry.value?.type || EntryValueType.Collection === subEntry.value?.type) {
+          @if (editorId()) {
+            <entry-object-editor
+              matLine
+              class="entry-editor-subentries-list-item"
+              [reactiveEntry]="subEntry"
+              [editorId]="editorId()!"
+              [disabled]="disabled()">
+            </entry-object-editor>
+          }
+        } @else if (EntryValueType.Boolean === subEntry.value?.type) {
+          <entry-boolean-editor
+            matLine
+            class="entry-editor-subentries-list-item"
+            [reactiveEntry]="subEntry"
+            [disabled]="disabled()">
+          </entry-boolean-editor>
+        } @else if (EntryValueType.Enum === subEntry.value?.type ||
+                    ((subEntry.value?.possible?.length ?? 0) > 1 &&
+                     subEntry.value?.type !== EntryValueType.Collection &&
+                     !isEntryTypeSettable(subEntry))) {
+          <entry-enum-editor
+            matLine
+            class="entry-editor-subentries-list-item"
+            [reactiveEntry]="subEntry"
+            [disabled]="disabled()">
+          </entry-enum-editor>
+        } @else if (isPrimitiveType(subEntry)) {
+          <entry-input-editor
+            matLine
+            class="entry-editor-subentries-list-item"
+            [reactiveEntry]="subEntry"
+            [disabled]="disabled()">
+          </entry-input-editor>
         }
-      } @else if (EntryValueType.Boolean === subEntry.value?.type) {
-        <entry-boolean-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
-        </entry-boolean-editor>
-      } @else if (EntryValueType.Enum === subEntry.value?.type ||
-                  ((subEntry.value?.possible?.length ?? 0) > 1 &&
-                   subEntry.value?.type !== EntryValueType.Collection &&
-                   !isEntryTypeSettable(subEntry))) {
-        <entry-enum-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
-        </entry-enum-editor>
-      } @else if (isPrimitiveType(subEntry)) {
-        <entry-input-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
-        </entry-input-editor>
       }
-    }
-  </mat-list>
+    </mat-list>
+  }
 }

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -134,12 +134,12 @@ export class EntryEditor {
   }
 
   private initializeFromReactiveEntry(re: ReactiveEntry) {
-    const entry = re.entry();
-    if (entry.value.type == EntryValueType.Collection) {
-      this.possibleListItemTypes.set(entry.value.possible);
-      this.prototypes.set(entry.prototypes ?? []);
-      if (entry.value.possible !== undefined && entry.value.possible !== null && entry.value.default !== null) {
-        this.selectedListItemType.set(entry.value.default);
+    const entryValue = re.value;
+    if (entryValue.type == EntryValueType.Collection) {
+      this.possibleListItemTypes.set(entryValue.possible);
+      this.prototypes.set(re.prototypes ?? []);
+      if (entryValue.possible !== undefined && entryValue.possible !== null && entryValue.default !== null) {
+        this.selectedListItemType.set(entryValue.default);
       }
     }
   }
@@ -153,7 +153,9 @@ export class EntryEditor {
 
   addItemToList() {
     const re = this._re();
-    if (!re) return;
+    if (!re) {
+      return;
+    }
 
     const prototypes = this.prototypes();
 
@@ -192,13 +194,12 @@ export class EntryEditor {
   }
 
   onPatchToSelectedEntryType(keyPair: EntryPossible): void {
-    const re = this._re();
-    if (!re) {
+    const reactiveEntry = this._re();
+    if (!reactiveEntry) {
       return;
     }
 
-    const currentEntry = re.entry();
-    const prototype = currentEntry?.prototypes?.find((proto: Entry) => proto.identifier === keyPair.key);
+    const prototype = reactiveEntry.prototypes.find((proto: Entry) => proto.identifier === keyPair.key);
 
     if (!prototype) {
       this.selectedEntryHasPrototypes.set(false);
@@ -207,14 +208,14 @@ export class EntryEditor {
 
     // Build the new entry from the prototype
     const entryPrototype = PrototypeToEntryConverter.entryFromPrototype(prototype);
-    entryPrototype.prototypes = JSON.parse(JSON.stringify(currentEntry.prototypes));
-    entryPrototype.value.possible = currentEntry.value.possible;
-    entryPrototype.displayName = currentEntry.displayName;
-    entryPrototype.identifier = currentEntry.identifier;
+    entryPrototype.prototypes = JSON.parse(JSON.stringify(reactiveEntry.prototypes));
+    entryPrototype.value.possible = reactiveEntry.value.possible;
+    entryPrototype.displayName = reactiveEntry.displayName;
+    entryPrototype.identifier = reactiveEntry.identifier;
 
     // Clear sub-entries and replace entry
-    re.clearSubEntries();
-    re.replaceEntry(entryPrototype);
+    reactiveEntry.clearSubEntries();
+    reactiveEntry.replaceEntry(entryPrototype);
 
     this.selectedEntryHasPrototypes.set(true);
   }
@@ -223,20 +224,20 @@ export class EntryEditor {
     this.onPatchToSelectedEntryType(event.value);
   }
 
-  isPrimitiveType(re: ReactiveEntry) {
-    return re.value.type !== EntryValueType.Collection &&
-      (re.value.possible && re.value.possible.length === 1) ||
-      (((re.value.possible && re.value.possible.length < 1) || !re.value.possible) &&
-        (EntryValueType.Byte === re.value?.type ||
-          EntryValueType.Int16 === re.value?.type ||
-          EntryValueType.UInt16 === re.value?.type ||
-          EntryValueType.Int32 === re.value?.type ||
-          EntryValueType.UInt32 === re.value?.type ||
-          EntryValueType.Int64 === re.value?.type ||
-          EntryValueType.UInt64 === re.value?.type ||
-          EntryValueType.Single === re.value?.type ||
-          EntryValueType.Double === re.value?.type ||
-          EntryValueType.String === re.value?.type ||
-          EntryValueType.Exception === re.value?.type));
+  isPrimitiveType(reactiveEntry: ReactiveEntry) {
+    return reactiveEntry.value.type !== EntryValueType.Collection &&
+      (reactiveEntry.value.possible && reactiveEntry.value.possible.length === 1) ||
+      (((reactiveEntry.value.possible && reactiveEntry.value.possible.length < 1) || !reactiveEntry.value.possible) &&
+        (EntryValueType.Byte === reactiveEntry.value.type ||
+          EntryValueType.Int16 === reactiveEntry.value.type ||
+          EntryValueType.UInt16 === reactiveEntry.value.type ||
+          EntryValueType.Int32 === reactiveEntry.value.type ||
+          EntryValueType.UInt32 === reactiveEntry.value.type ||
+          EntryValueType.Int64 === reactiveEntry.value.type ||
+          EntryValueType.UInt64 === reactiveEntry.value.type ||
+          EntryValueType.Single === reactiveEntry.value.type ||
+          EntryValueType.Double === reactiveEntry.value.type ||
+          EntryValueType.String === reactiveEntry.value.type ||
+          EntryValueType.Exception === reactiveEntry.value.type));
   }
 }

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -74,6 +74,7 @@ export class EntryEditor {
   }
 
   constructor() {
+    // Existing effect for initialization
     effect(() => {
       const reactiveInput = this.reactiveEntry();
       const entryInput = this.entry();
@@ -90,6 +91,24 @@ export class EntryEditor {
           this._re.set(re);
           this.initializeFromReactiveEntry(re);
         }
+      });
+    });
+
+    // Sync changes back to entry model (standalone mode only)
+    effect(() => {
+      const reactiveInput = this.reactiveEntry();
+      const re = this._re();
+
+      // Only sync in standalone mode (no reactiveEntry input)
+      if (reactiveInput || !re) {
+        return;
+      }
+
+      const changedEntry = re.changed();
+
+      untracked(() => {
+        this._lastEntryRef = changedEntry;
+        this.entry.set(changedEntry);
       });
     });
   }
@@ -120,7 +139,7 @@ export class EntryEditor {
 
     if (this.selectedListItemType() && prototypes) {
       let prototype: Entry | undefined;
-      for (var i = 0; i < prototypes.length; i++) {
+      for (let i = 0; i < prototypes.length; i++) {
         if (prototypes[i].value.type == EntryValueType.Class) {
           prototype = prototypes.find(x => x.identifier === this.selectedListItemType());
         } else {

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -1,5 +1,6 @@
-import { Component, effect, input, model, signal } from '@angular/core';
+import { Component, effect, input, model, signal, untracked } from '@angular/core';
 import { Entry } from './models/entry';
+import { ReactiveEntry } from './reactive-entry';
 import { EntryPossible } from './models/entry-possible';
 import { EntryUnitType } from './models/entry-unit-type';
 import { EntryValueType } from './models/entry-value-type';
@@ -46,9 +47,17 @@ export class EntryEditor {
   editorId = input<number | undefined>(undefined);
   disabled = input<boolean>(false);
 
-  entry = model.required<Entry>();
-  currentEntry: Entry | undefined = undefined;
-  subEntries = signal<Entry[]>([]);
+  // Standalone mode: plain Entry
+  entry = model<Entry | undefined>(undefined);
+
+  // Wrapped mode: ReactiveEntry from NavigableEntryEditor
+  reactiveEntry = input<ReactiveEntry | undefined>(undefined);
+
+  // Unified internal signal for sub-components
+  private _re = signal<ReactiveEntry | null>(null);
+
+  // Track the last processed entry to avoid redundant conversions
+  private _lastEntryRef: Entry | undefined = undefined;
 
   possibleListItemTypes = signal<EntryPossible[] | undefined | null>(undefined);
   prototypes = signal<Entry[]>([]);
@@ -57,16 +66,34 @@ export class EntryEditor {
 
   private createdCounter?: number;
 
+  // Expose for template
+  get re(): ReactiveEntry | null {
+    return this._re();
+  }
+
   constructor() {
     effect(() => {
-      if(this.currentEntry !== this.entry() ){
-        this.initialize(this.entry());
-        this.currentEntry = this.entry();
-      }
+      const reactiveInput = this.reactiveEntry();
+      const entryInput = this.entry();
+
+      untracked(() => {
+        if (reactiveInput) {
+          // Wrapped mode - use provided ReactiveEntry
+          this._re.set(reactiveInput);
+          this.initializeFromReactiveEntry(reactiveInput);
+        } else if (entryInput && entryInput !== this._lastEntryRef) {
+          // Standalone mode - convert Entry to ReactiveEntry
+          this._lastEntryRef = entryInput;
+          const re = ReactiveEntry.fromEntry(entryInput);
+          this._re.set(re);
+          this.initializeFromReactiveEntry(re);
+        }
+      });
     });
   }
 
-  private initialize(entry: Entry) {
+  private initializeFromReactiveEntry(re: ReactiveEntry) {
+    const entry = re.entry();
     if (entry.value.type == 'Collection') {
       this.possibleListItemTypes.set(entry.value.possible);
       this.prototypes.set(entry.prototypes ?? []);
@@ -76,48 +103,36 @@ export class EntryEditor {
     }
   }
 
-  updateSubEntry(subEntry: Entry) {
-    this.entry.update(item => {
-      const match = item.subEntries?.find(x => x.identifier === subEntry.identifier);
-      if (match)
-        Object.assign(match, subEntry);
-      else
-        item.subEntries?.push(subEntry);
-      return item;
-    });
-  }
-
   EntryValueType = EntryValueType;
   EntryUnitType = EntryUnitType;
 
-  onDeleteListItem(toBeDeleted: Entry) {
-    const entry = this.entry();
-
-    if (entry.subEntries !== undefined && entry.subEntries !== null) {
-      var index = entry.subEntries.findIndex(c => c.identifier === toBeDeleted.identifier);
-      if (index > -1) {
-        entry.subEntries.splice(index, 1);
-        this.entry.update(_ => entry);
-      }
+  onDeleteListItem(toBeDeleted: ReactiveEntry) {
+    const re = this._re();
+    if (re && toBeDeleted.identifier) {
+      re.removeSubEntry(toBeDeleted.identifier);
     }
   }
 
   addItemToList() {
+    const re = this._re();
+    if (!re) return;
+
     const prototypes = this.prototypes();
 
     if (this.selectedListItemType() && prototypes) {
+      let prototype: Entry | undefined;
       for (var i = 0; i < prototypes.length; i++) {
         if (prototypes[i].value.type == EntryValueType.Class) {
-          var prototype = prototypes.find(x => x.identifier === this.selectedListItemType());
+          prototype = prototypes.find(x => x.identifier === this.selectedListItemType());
         } else {
-          var prototype = prototypes.find(x => x.displayName === this.selectedListItemType());
+          prototype = prototypes.find(x => x.displayName === this.selectedListItemType());
         }
       }
       if (prototype) {
-        const currentEntry = this.entry();
         var entry = PrototypeToEntryConverter.cloneEntry(prototype);
-        if (currentEntry.subEntries && currentEntry.subEntries.length > 0) {
-          var last = currentEntry.subEntries[currentEntry.subEntries.length - 1];
+        const currentSubEntries = re.subEntries();
+        if (currentSubEntries && currentSubEntries.length > 0) {
+          var last = currentSubEntries[currentSubEntries.length - 1];
           var count = /\d+/;
           var current = last.identifier ? Number(last.identifier.match(count)) : 0;
           this.createdCounter = current + 1;
@@ -126,56 +141,62 @@ export class EntryEditor {
         }
         if (this.createdCounter) {
           entry.identifier = 'CREATED' + this.createdCounter;
-          currentEntry.subEntries?.push(entry);
-          this.entry.update(_ => currentEntry);
+          re.addSubEntry(entry);
         }
       }
     }
   }
 
-  isEntryTypeSettable(entry: Entry): boolean {
-    return  entry?.value?.type === EntryValueType.Class &&
-      entry.value.possible != null &&
-      entry.value.possible.length > 1;
+  isEntryTypeSettable(re: ReactiveEntry): boolean {
+    return re?.value?.type === EntryValueType.Class &&
+      re.value.possible != null &&
+      re.value.possible.length > 1;
   }
 
   onPatchToSelectedEntryType(keyPair: EntryPossible): void {
-    this.entry.update(entry => {
-      entry.subEntries = [];
-      const prototype = entry?.prototypes?.find((proto: Entry) => proto.identifier === keyPair.key);
-      if (!prototype) {
-        this.selectedEntryHasPrototypes.set(false);
-        return entry;
-      }
-      const entryPrototype = PrototypeToEntryConverter.entryFromPrototype(prototype);
-      entryPrototype.prototypes = JSON.parse(JSON.stringify(entry.prototypes));
-      entryPrototype.value.possible = entry.value.possible;
-      entryPrototype.displayName = entry.displayName;
-      entryPrototype.identifier = entry.identifier;
-      Object.assign(entry, entryPrototype);
-      this.selectedEntryHasPrototypes.set(true);
-      return entry;
-    });
+    const re = this._re();
+    if (!re) return;
+
+    const currentEntry = re.entry();
+    const prototype = currentEntry?.prototypes?.find((proto: Entry) => proto.identifier === keyPair.key);
+
+    if (!prototype) {
+      this.selectedEntryHasPrototypes.set(false);
+      return;
+    }
+
+    // Build the new entry from the prototype
+    const entryPrototype = PrototypeToEntryConverter.entryFromPrototype(prototype);
+    entryPrototype.prototypes = JSON.parse(JSON.stringify(currentEntry.prototypes));
+    entryPrototype.value.possible = currentEntry.value.possible;
+    entryPrototype.displayName = currentEntry.displayName;
+    entryPrototype.identifier = currentEntry.identifier;
+
+    // Clear sub-entries and replace entry
+    re.clearSubEntries();
+    re.replaceEntry(entryPrototype);
+
+    this.selectedEntryHasPrototypes.set(true);
   }
 
-  dropdownSelectionChanged(event: MatSelectChange){
+  dropdownSelectionChanged(event: MatSelectChange) {
     this.onPatchToSelectedEntryType(event.value);
   }
 
-  isPrimitiveType(entry: Entry){
-    return entry.value.type !== EntryValueType.Collection &&
-      (entry.value.possible && entry.value.possible.length === 1) ||
-      (((entry.value.possible && entry.value.possible.length < 1) || !entry.value.possible)  &&
-        (EntryValueType.Byte === entry.value?.type ||
-          EntryValueType.Int16 === entry.value?.type ||
-          EntryValueType.UInt16 === entry.value?.type ||
-          EntryValueType.Int32 === entry.value?.type ||
-          EntryValueType.UInt32 === entry.value?.type ||
-          EntryValueType.Int64 === entry.value?.type ||
-          EntryValueType.UInt64 === entry.value?.type ||
-          EntryValueType.Single === entry.value?.type ||
-          EntryValueType.Double === entry.value?.type ||
-          EntryValueType.String === entry.value?.type ||
-          EntryValueType.Exception === entry.value?.type));
+  isPrimitiveType(re: ReactiveEntry) {
+    return re.value.type !== EntryValueType.Collection &&
+      (re.value.possible && re.value.possible.length === 1) ||
+      (((re.value.possible && re.value.possible.length < 1) || !re.value.possible) &&
+        (EntryValueType.Byte === re.value?.type ||
+          EntryValueType.Int16 === re.value?.type ||
+          EntryValueType.UInt16 === re.value?.type ||
+          EntryValueType.Int32 === re.value?.type ||
+          EntryValueType.UInt32 === re.value?.type ||
+          EntryValueType.Int64 === re.value?.type ||
+          EntryValueType.UInt64 === re.value?.type ||
+          EntryValueType.Single === re.value?.type ||
+          EntryValueType.Double === re.value?.type ||
+          EntryValueType.String === re.value?.type ||
+          EntryValueType.Exception === re.value?.type));
   }
 }

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -8,7 +8,7 @@ import { BooleanEditor } from './boolean-editor/boolean-editor';
 import { MatLineModule, MatOption } from '@angular/material/core';
 import { CommonModule, NgClass } from '@angular/common';
 import { MatList } from '@angular/material/list';
-import { MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
+import { MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
 import { MatSelect, MatSelectChange } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
 import { EnumEditor } from './enum-editor/enum-editor';
@@ -61,6 +61,10 @@ export class EntryEditor {
   // Track the last processed entry to avoid redundant conversions
   private _lastEntryRef: Entry | undefined = undefined;
 
+  // Track which ReactiveEntry instance we have seen and its last synced version
+  private _lastSyncedReactiveEntry: ReactiveEntry | null = null;
+  private _lastSyncedVersion = 0;
+
   possibleListItemTypes = signal<EntryPossible[] | undefined | null>(undefined);
   prototypes = signal<Entry[]>([]);
   selectedListItemType = signal<string | undefined>(undefined);
@@ -104,9 +108,25 @@ export class EntryEditor {
         return;
       }
 
+      const version = re.version();
+
+      // If this is a new ReactiveEntry instance, record it and skip initial sync
+      if (re !== this._lastSyncedReactiveEntry) {
+        this._lastSyncedReactiveEntry = re;
+        this._lastSyncedVersion = version;
+        return;
+      }
+
+      // Only sync when version has increased (actual mutation occurred)
+      if (version <= this._lastSyncedVersion) {
+        return;
+      }
+
       const changedEntry = re.changed();
 
       untracked(() => {
+        // Track that we have synced this version
+        this._lastSyncedVersion = version;
         this._lastEntryRef = changedEntry;
         this.entry.set(changedEntry);
       });
@@ -115,7 +135,7 @@ export class EntryEditor {
 
   private initializeFromReactiveEntry(re: ReactiveEntry) {
     const entry = re.entry();
-    if (entry.value.type == 'Collection') {
+    if (entry.value.type == EntryValueType.Collection) {
       this.possibleListItemTypes.set(entry.value.possible);
       this.prototypes.set(entry.prototypes ?? []);
       if (entry.value.possible !== undefined && entry.value.possible !== null && entry.value.default !== null) {
@@ -173,7 +193,9 @@ export class EntryEditor {
 
   onPatchToSelectedEntryType(keyPair: EntryPossible): void {
     const re = this._re();
-    if (!re) return;
+    if (!re) {
+      return;
+    }
 
     const currentEntry = re.entry();
     const prototype = currentEntry?.prototypes?.find((proto: Entry) => proto.identifier === keyPair.key);

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -2,7 +2,6 @@ import { Component, effect, input, model, signal, untracked } from '@angular/cor
 import { Entry } from './models/entry';
 import { ReactiveEntry } from './reactive-entry';
 import { EntryPossible } from './models/entry-possible';
-import { EntryUnitType } from './models/entry-unit-type';
 import { EntryValueType } from './models/entry-value-type';
 import { PrototypeToEntryConverter } from './prototype-to-entry-converter';
 import { BooleanEditor } from './boolean-editor/boolean-editor';
@@ -52,6 +51,9 @@ export class EntryEditor {
 
   // Wrapped mode: ReactiveEntry from NavigableEntryEditor
   reactiveEntry = input<ReactiveEntry | undefined>(undefined);
+
+  // Re-exports for template access
+  EntryValueType = EntryValueType;
 
   // Unified internal signal for sub-components
   private _re = signal<ReactiveEntry | null>(null);
@@ -103,9 +105,6 @@ export class EntryEditor {
     }
   }
 
-  EntryValueType = EntryValueType;
-  EntryUnitType = EntryUnitType;
-
   onDeleteListItem(toBeDeleted: ReactiveEntry) {
     const re = this._re();
     if (re && toBeDeleted.identifier) {
@@ -129,12 +128,12 @@ export class EntryEditor {
         }
       }
       if (prototype) {
-        var entry = PrototypeToEntryConverter.cloneEntry(prototype);
+        const entry = PrototypeToEntryConverter.cloneEntry(prototype);
         const currentSubEntries = re.subEntries();
         if (currentSubEntries && currentSubEntries.length > 0) {
-          var last = currentSubEntries[currentSubEntries.length - 1];
-          var count = /\d+/;
-          var current = last.identifier ? Number(last.identifier.match(count)) : 0;
+          const last = currentSubEntries[currentSubEntries.length - 1];
+          const count = /\d+/;
+          const current = last.identifier ? Number(last.identifier.match(count)) : 0;
           this.createdCounter = current + 1;
         } else {
           this.createdCounter = 1;

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
@@ -1,45 +1,45 @@
 <div class="full-width-input">
   <div class="entry-list-item-content">
-    @if (EntryValueType.Stream === entry().value?.type) {
+    @if (EntryValueType.Stream === reactiveEntry().value?.type) {
       <entry-file-editor
         matLine
         class="entry-list-item-value"
-        [entry]="entry()"
+        [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Class === entry().value?.type || EntryValueType.Collection === entry().value?.type) {
+    } @else if (EntryValueType.Class === reactiveEntry().value?.type || EntryValueType.Collection === reactiveEntry().value?.type) {
       <entry-object-editor
         matLine
         class="entry-list-item-value"
-        [entry]="entry()"
+        [reactiveEntry]="reactiveEntry()"
         [editorId]="editorId()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Boolean === entry().value?.type) {
+    } @else if (EntryValueType.Boolean === reactiveEntry().value?.type) {
       <entry-boolean-editor
         matLine
         class="entry-list-item-value"
-        [entry]="entry()"
+        [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Enum === entry().value?.type) {
+    } @else if (EntryValueType.Enum === reactiveEntry().value?.type) {
       <entry-enum-editor
         matLine
         class="entry-list-item-value"
-        [entry]="entry()"
+        [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Byte === entry().value?.type ||
-                EntryValueType.Int16 === entry().value?.type ||
-                EntryValueType.UInt16 === entry().value?.type ||
-                EntryValueType.Int32 === entry().value?.type ||
-                EntryValueType.UInt32 === entry().value?.type ||
-                EntryValueType.Int64 === entry().value?.type ||
-                EntryValueType.UInt64 === entry().value?.type ||
-                EntryValueType.Single === entry().value?.type ||
-                EntryValueType.Double === entry().value?.type ||
-                EntryValueType.String === entry().value?.type ||
-                EntryValueType.Exception === entry().value?.type) {
+    } @else if (EntryValueType.Byte === reactiveEntry().value?.type ||
+                EntryValueType.Int16 === reactiveEntry().value?.type ||
+                EntryValueType.UInt16 === reactiveEntry().value?.type ||
+                EntryValueType.Int32 === reactiveEntry().value?.type ||
+                EntryValueType.UInt32 === reactiveEntry().value?.type ||
+                EntryValueType.Int64 === reactiveEntry().value?.type ||
+                EntryValueType.UInt64 === reactiveEntry().value?.type ||
+                EntryValueType.Single === reactiveEntry().value?.type ||
+                EntryValueType.Double === reactiveEntry().value?.type ||
+                EntryValueType.String === reactiveEntry().value?.type ||
+                EntryValueType.Exception === reactiveEntry().value?.type) {
       <entry-input-editor
         matLine
         class="entry-list-item-value"
-        [entry]="entry()"
+        [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
     }
 

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
@@ -1,41 +1,41 @@
 <div class="full-width-input">
   <div class="entry-list-item-content">
-    @if (EntryValueType.Stream === reactiveEntry().value?.type) {
+    @if (EntryValueType.Stream === reactiveEntry().value.type) {
       <entry-file-editor
         matLine
         class="entry-list-item-value"
         [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Class === reactiveEntry().value?.type || EntryValueType.Collection === reactiveEntry().value?.type) {
+    } @else if (EntryValueType.Class === reactiveEntry().value.type || EntryValueType.Collection === reactiveEntry().value.type) {
       <entry-object-editor
         matLine
         class="entry-list-item-value"
         [reactiveEntry]="reactiveEntry()"
         [editorId]="editorId()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Boolean === reactiveEntry().value?.type) {
+    } @else if (EntryValueType.Boolean === reactiveEntry().value.type) {
       <entry-boolean-editor
         matLine
         class="entry-list-item-value"
         [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Enum === reactiveEntry().value?.type) {
+    } @else if (EntryValueType.Enum === reactiveEntry().value.type) {
       <entry-enum-editor
         matLine
         class="entry-list-item-value"
         [reactiveEntry]="reactiveEntry()"
         [disabled]="disabled()" />
-    } @else if (EntryValueType.Byte === reactiveEntry().value?.type ||
-                EntryValueType.Int16 === reactiveEntry().value?.type ||
-                EntryValueType.UInt16 === reactiveEntry().value?.type ||
-                EntryValueType.Int32 === reactiveEntry().value?.type ||
-                EntryValueType.UInt32 === reactiveEntry().value?.type ||
-                EntryValueType.Int64 === reactiveEntry().value?.type ||
-                EntryValueType.UInt64 === reactiveEntry().value?.type ||
-                EntryValueType.Single === reactiveEntry().value?.type ||
-                EntryValueType.Double === reactiveEntry().value?.type ||
-                EntryValueType.String === reactiveEntry().value?.type ||
-                EntryValueType.Exception === reactiveEntry().value?.type) {
+    } @else if (EntryValueType.Byte === reactiveEntry().value.type ||
+                EntryValueType.Int16 === reactiveEntry().value.type ||
+                EntryValueType.UInt16 === reactiveEntry().value.type ||
+                EntryValueType.Int32 === reactiveEntry().value.type ||
+                EntryValueType.UInt32 === reactiveEntry().value.type ||
+                EntryValueType.Int64 === reactiveEntry().value.type ||
+                EntryValueType.UInt64 === reactiveEntry().value.type ||
+                EntryValueType.Single === reactiveEntry().value.type ||
+                EntryValueType.Double === reactiveEntry().value.type ||
+                EntryValueType.String === reactiveEntry().value.type ||
+                EntryValueType.Exception === reactiveEntry().value.type) {
       <entry-input-editor
         matLine
         class="entry-list-item-value"

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
@@ -1,9 +1,9 @@
 import { Component, computed, EventEmitter, input, Output } from '@angular/core';
-import { Entry } from '../models/entry';
+import { ReactiveEntry } from '../reactive-entry';
 import { EntryUnitType } from '../models/entry-unit-type';
 import { EntryValueType } from '../models/entry-value-type';
 import { FileEditor } from '../file-editor/file-editor';
-import { EntryObject} from '../entry-object/entry-object';
+import { EntryObject } from '../entry-object/entry-object';
 import { BooleanEditor } from '../boolean-editor/boolean-editor';
 import { InputEditor } from '../input-editor/input-editor';
 import { EnumEditor } from '../enum-editor/enum-editor';
@@ -29,19 +29,22 @@ import { MatListModule } from '@angular/material/list';
   styleUrl: './entry-list-item.scss',
 })
 export class EntryListItem {
-  entry = input.required<Entry>();
+  reactiveEntry = input.required<ReactiveEntry>();
   editorId = input.required<number>();
   disabled = input<boolean>(false);
-  @Output() deleteRequest: EventEmitter<Entry> = new EventEmitter<Entry>();
+  @Output() deleteRequest: EventEmitter<ReactiveEntry> = new EventEmitter<ReactiveEntry>();
+
   isObjectType = computed(() => {
-    return EntryValueType.Class === this.entry().value?.type || EntryValueType.Collection === this.entry().value?.type;
+    const value = this.reactiveEntry().value;
+    return EntryValueType.Class === value?.type || EntryValueType.Collection === value?.type;
   });
 
   EntryValueType = EntryValueType;
   EntryUnitType = EntryUnitType;
+
   constructor() {}
 
   onDelete() {
-    this.deleteRequest.emit(this.entry());
+    this.deleteRequest.emit(this.reactiveEntry());
   }
 }

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
@@ -1,6 +1,5 @@
-import { Component, computed, EventEmitter, input, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { ReactiveEntry } from '../reactive-entry';
-import { EntryUnitType } from '../models/entry-unit-type';
 import { EntryValueType } from '../models/entry-value-type';
 import { FileEditor } from '../file-editor/file-editor';
 import { EntryObject } from '../entry-object/entry-object';
@@ -23,7 +22,7 @@ import { MatListModule } from '@angular/material/list';
     CommonModule,
     MatLine,
     MatIconButton,
-    MatListModule,
+    MatListModule
   ],
   templateUrl: './entry-list-item.html',
   styleUrl: './entry-list-item.scss',
@@ -32,17 +31,10 @@ export class EntryListItem {
   reactiveEntry = input.required<ReactiveEntry>();
   editorId = input.required<number>();
   disabled = input<boolean>(false);
-  @Output() deleteRequest: EventEmitter<ReactiveEntry> = new EventEmitter<ReactiveEntry>();
 
-  isObjectType = computed(() => {
-    const value = this.reactiveEntry().value;
-    return EntryValueType.Class === value?.type || EntryValueType.Collection === value?.type;
-  });
+  deleteRequest = output<ReactiveEntry>();
 
   EntryValueType = EntryValueType;
-  EntryUnitType = EntryUnitType;
-
-  constructor() {}
 
   onDelete() {
     this.deleteRequest.emit(this.reactiveEntry());

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
@@ -1,12 +1,12 @@
 <div class="entry-object-wrapper">
   <button mat-stroked-button (click)="onOpen()" class="full-width-input entry-object-container" type="button">
     <div class="entry-object">
-      <span class="entry-object-text">{{ entry().displayName }}</span>
+      <span class="entry-object-text">{{ reactiveEntry().displayName }}</span>
       <span class="material-symbols-outlined"> chevron_right </span>
     </div>
   </button>
 
-  <div class="object-entry-hint" [class.entry-editor-disabled]="disabled() || (entry().value.isReadOnly ?? false)">
-    {{ entry().description }}
+  <div class="object-entry-hint" [class.entry-editor-disabled]="disabled() || (reactiveEntry().value.isReadOnly ?? false)">
+    {{ reactiveEntry().description }}
   </div>
 </div>

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.ts
@@ -1,5 +1,5 @@
 import { Component, inject, input } from '@angular/core';
-import { Entry } from '../models/entry';
+import { ReactiveEntry } from '../reactive-entry';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { NavigableEntryService } from '../services/navigable-entry.service';
@@ -13,11 +13,12 @@ import { NavigableEntryService } from '../services/navigable-entry.service';
 export class EntryObject {
   private navigableEntryService = inject(NavigableEntryService);
 
-  entry = input.required<Entry>();
+  reactiveEntry = input.required<ReactiveEntry>();
   editorId = input.required<number>();
   disabled = input<boolean>(false);
 
-  onOpen(){
-    this.navigableEntryService.onOpenEntry(this.editorId(), this.entry());
+  onOpen() {
+    // Convert ReactiveEntry back to Entry for navigation service
+    this.navigableEntryService.onOpenEntry(this.editorId(), this.reactiveEntry().toEntry());
   }
 }

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
@@ -1,14 +1,14 @@
 <mat-form-field class="full-width-input entry-form-field" appearance="outline">
-  <mat-label>{{entry().displayName}}</mat-label>
+  <mat-label>{{ reactiveEntry().displayName }}</mat-label>
   <mat-select [formControl]="formControl" (selectionChange)="changed($event)"
               [multiple]="isFlagEnum()">
-    @for (pv of entry().value.possible; track pv) {
+    @for (pv of reactiveEntry().value.possible; track pv) {
       <mat-option [value]="pv.key">
         {{ pv.displayName ?? pv.key }}
       </mat-option>
     }
   </mat-select>
-  <mat-hint [ngClass]="{'entry-editor-disabled': (disabled() || (entry().value.isReadOnly ?? false))}" class="truncate">
-    {{entry().description}}
+  <mat-hint [ngClass]="{'entry-editor-disabled': (disabled() || (reactiveEntry().value.isReadOnly ?? false))}" class="truncate">
+    {{ reactiveEntry().description }}
   </mat-hint>
 </mat-form-field>

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
@@ -1,7 +1,7 @@
 <mat-form-field class="full-width-input entry-form-field" appearance="outline">
   <mat-label>{{ reactiveEntry().displayName }}</mat-label>
   <mat-select [formControl]="formControl" (selectionChange)="changed($event)"
-              [multiple]="isFlagEnum()">
+              [multiple]="reactiveEntry().value.unitType === EntryUnitType.Flags">
     @for (pv of reactiveEntry().value.possible; track pv.key) {
       <mat-option [value]="pv.key">
         {{ pv.displayName ?? pv.key }}

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
@@ -2,7 +2,7 @@
   <mat-label>{{ reactiveEntry().displayName }}</mat-label>
   <mat-select [formControl]="formControl" (selectionChange)="changed($event)"
               [multiple]="isFlagEnum()">
-    @for (pv of reactiveEntry().value.possible; track pv) {
+    @for (pv of reactiveEntry().value.possible; track pv.key) {
       <mat-option [value]="pv.key">
         {{ pv.displayName ?? pv.key }}
       </mat-option>

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
@@ -17,6 +17,8 @@ export class EnumEditor {
   reactiveEntry = input.required<ReactiveEntry>();
   formControl = new UntypedFormControl('');
 
+  EntryUnitType = EntryUnitType;
+
   constructor() {
     effect(() => {
       const disabled = this.disabled();
@@ -28,17 +30,17 @@ export class EnumEditor {
   }
 
   private initialize(re: ReactiveEntry, disabled: boolean) {
-    const entry = re.entry();
-    const value = entry.value?.current ?? entry.value?.default;
+    const entryValue = re.value;
+    const value = entryValue.current ?? entryValue.default;
 
-    if (entry.value.unitType === EntryUnitType.Flags) {
+    if (entryValue.unitType === EntryUnitType.Flags) {
       const list = value?.split(',').map(str => str.trim()) ?? [];
       this.formControl.patchValue(list);
     } else {
       this.formControl.patchValue(value);
     }
 
-    if (disabled || (entry.value.isReadOnly ?? false)) {
+    if (disabled || (entryValue.isReadOnly ?? false)) {
       this.formControl.disable();
     } else {
       this.formControl.enable();
@@ -57,10 +59,6 @@ export class EnumEditor {
       newValue = '0';
     }
 
-    this.reactiveEntry().setCurrent(newValue);
-  }
-
-  isFlagEnum(): boolean {
-    return this.reactiveEntry().value.unitType === EntryUnitType.Flags;
+    this.reactiveEntry().setCurrentValue(newValue);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
@@ -1,72 +1,66 @@
-import { Component, effect, input, model, untracked } from '@angular/core';
-import { Entry } from '../models/entry';
+import { Component, effect, input, untracked } from '@angular/core';
+import { ReactiveEntry } from '../reactive-entry';
 import { CommonModule } from '@angular/common';
-import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { EntryUnitType } from '../models/entry-unit-type';
 
 @Component({
   selector: 'entry-enum-editor',
-  imports: [CommonModule, MatFormField, MatLabel, MatSelect, MatOption, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, MatFormField, MatLabel, MatSelect, MatOption, FormsModule, ReactiveFormsModule, MatHint],
   templateUrl: './enum-editor.html',
   styleUrl: './enum-editor.scss',
 })
 export class EnumEditor {
   disabled = input<boolean>(false);
-  entry = model.required<Entry>();
+  reactiveEntry = input.required<ReactiveEntry>();
   formControl = new UntypedFormControl('');
 
   constructor() {
     effect(() => {
       const disabled = this.disabled();
       untracked(() => {
-        const entry = Object.assign(this.entry());
-        this.initialize(entry, disabled);
+        const re = this.reactiveEntry();
+        this.initialize(re, disabled);
       });
     });
   }
 
-  private initialize(entry: Entry, disabled: boolean) {
-    this.entry.update(e => {
-      const value = entry.value?.current ?? entry.value?.default;
-      if (entry.value.unitType === EntryUnitType.Flags) {
-        const list = value?.split(',').map(str => str.trim()) ?? [];
-        this.formControl.patchValue(list);
-      } else {
-        this.formControl.patchValue(value);
-      }
+  private initialize(re: ReactiveEntry, disabled: boolean) {
+    const entry = re.entry();
+    const value = entry.value?.current ?? entry.value?.default;
 
-      let copy = Object.assign({}, e);
-      copy.value.current = value;
-      return copy;
-    });
-
-    if (disabled || (entry.value.isReadOnly ?? false)) this.formControl.disable();
-    else this.formControl.enable();
-  }
-
-  changed(event: any) {
-    if (Array.isArray(this.formControl.value) && this.formControl.value.length > 0) {
-      this.entry.update(e => {
-        e.value.current = this.formControl.value.join(",");
-        return e;
-      });
-    } else if (typeof this.formControl.value === 'string' && this.formControl.value.trim().length > 0) {
-      this.entry.update(e => {
-        e.value.current = this.formControl.value;
-        return e;
-      });
+    if (entry.value.unitType === EntryUnitType.Flags) {
+      const list = value?.split(',').map(str => str.trim()) ?? [];
+      this.formControl.patchValue(list);
     } else {
-      console.warn("EnumEditor: No value selected, value is now set to 0");
-      this.entry.update(e => {
-        e.value.current = "0";
-        return e;
-      });
+      this.formControl.patchValue(value);
+    }
+
+    if (disabled || (entry.value.isReadOnly ?? false)) {
+      this.formControl.disable();
+    } else {
+      this.formControl.enable();
     }
   }
 
+  changed(event: any) {
+    let newValue: string;
+
+    if (Array.isArray(this.formControl.value) && this.formControl.value.length > 0) {
+      newValue = this.formControl.value.join(',');
+    } else if (typeof this.formControl.value === 'string' && this.formControl.value.trim().length > 0) {
+      newValue = this.formControl.value;
+    } else {
+      console.warn('EnumEditor: No value selected, value is now set to 0');
+      newValue = '0';
+    }
+
+    this.reactiveEntry().setCurrent(newValue);
+  }
+
   isFlagEnum(): boolean {
-    return this.entry().value.unitType === EntryUnitType.Flags
+    return this.reactiveEntry().value.unitType === EntryUnitType.Flags;
   }
 }

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.html
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.html
@@ -2,7 +2,7 @@
   <input title="File Selector" type="file" class="file-input" (change)="onFileSelected($event)" #fileUpload />
   <div class="moryx-file-input file-upload">
     <mat-form-field appearance="outline" class="file-input-field entry-form-field">
-      <mat-label>{{ entry().displayName }}</mat-label>
+      <mat-label>{{ reactiveEntry().displayName }}</mat-label>
       <input
         matInput
         [formControl]="inputFormControl"
@@ -11,7 +11,7 @@
         class="file-input-field"
         [placeholder]="
           inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-            ? entry().value.default ?? ''
+            ? reactiveEntry().value.default ?? ''
             : ''
         " />
       <button
@@ -19,21 +19,21 @@
         (click)="fileUpload.click()"
         class="file-input-button"
         type="button"
-        [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+        [disabled]="disabled() || (reactiveEntry().value.isReadOnly ?? false)"
+        [ngClass]="{ 'entry-editor-disabled': disabled() || (reactiveEntry().value.isReadOnly ?? false) }"
         matSuffix>
         <span class="material-symbols-outlined">upload</span>
       </button>
       <mat-hint
-        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+        [ngClass]="{ 'entry-editor-disabled': disabled() || (reactiveEntry().value.isReadOnly ?? false) }"
         class="truncate">
-        {{ entry().description }}
+        {{ reactiveEntry().description }}
       </mat-hint>
     </mat-form-field>
   </div>
   @if (inputFormControl.hasError('required')) {
     <mat-error class="truncate">
-      {{ entry().displayName }} is <strong>required</strong>
+      {{ reactiveEntry().displayName }} is <strong>required</strong>
     </mat-error>
   }
 </div>

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
@@ -1,17 +1,16 @@
-import { Component, effect, input, model } from '@angular/core';
+import { Component, effect, input } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl, ValidatorFn, Validators } from '@angular/forms';
-import { Entry } from '../models/entry';
+import { ReactiveEntry } from '../reactive-entry';
 import { EntryValueType } from '../models/entry-value-type';
-import { EntryValue } from '../models/entry-value';
 import { CommonModule } from '@angular/common';
-import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatError, MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconButton } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'entry-file-editor',
-  imports: [CommonModule, MatFormField, MatLabel, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule],
+  imports: [CommonModule, MatFormField, MatLabel, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule, MatHint],
   templateUrl: './file-editor.html',
   styleUrl: './file-editor.scss',
 })
@@ -20,31 +19,29 @@ export class FileEditor {
   private readOnly: boolean | undefined = undefined;
 
   disabled = input<boolean>(false);
-  entry = model.required<Entry>();
+  reactiveEntry = input.required<ReactiveEntry>();
 
   constructor() {
     const reference = effect(() => {
-      this.initialize(this.entry());
+      this.initialize(this.reactiveEntry());
       reference.destroy();
-    })
+    });
 
     effect(() => {
       this.disableInputFormControl(this.inputFormControl, this.disabled());
     });
   }
 
-  private initialize(entry: Entry) {
-    const validators = this.setupValidators(entry);
-    this.inputFormControl = this.setupFormControl(entry, validators);
+  private initialize(re: ReactiveEntry) {
+    const entry = re.entry();
+    const validators = this.setupValidators(re);
+    this.inputFormControl = this.setupFormControl(re, validators);
     this.readOnly = entry.value?.isReadOnly;
   }
 
-  private updateCurrentValue(currentValue: EntryValue, value: any) {
-    this.entry.update(e => {
-      let copy = Object.assign({}, e);
-      copy.value.current = value ?? currentValue?.default;
-      return copy;
-    });
+  private updateCurrentValue(re: ReactiveEntry, value: any) {
+    const entry = re.entry();
+    re.setCurrent(value ?? entry.value?.default);
   }
 
   disableInputFormControl(control: UntypedFormControl, disable: boolean) {
@@ -54,7 +51,8 @@ export class FileEditor {
       control.enable();
   }
 
-  setupValidators(entry: Entry): ValidatorFn[] {
+  setupValidators(re: ReactiveEntry): ValidatorFn[] {
+    const entry = re.entry();
     let validators = [] as ValidatorFn[];
     if (entry.validation?.isRequired)
       validators.push(Validators.required);
@@ -62,7 +60,8 @@ export class FileEditor {
     return validators;
   }
 
-  private setupFormControl(entry: Entry, validators: ValidatorFn[]): UntypedFormControl {
+  private setupFormControl(re: ReactiveEntry, validators: ValidatorFn[]): UntypedFormControl {
+    const entry = re.entry();
     const initial = entry.value?.current ?? '';
 
     const ctrl = new UntypedFormControl(
@@ -76,9 +75,8 @@ export class FileEditor {
     return ctrl;
   }
 
-
-  onFileSelected(event: any){
-    const file:File = event.target.files[0];
+  onFileSelected(event: any) {
+    const file: File = event.target.files[0];
     if (file) {
       this.inputFormControl.setValue(file.name);
       const reader = new FileReader();
@@ -90,11 +88,10 @@ export class FileEditor {
             .replace('data:', '')
             .replace(/^.+,/, '');
 
-          this.updateCurrentValue(this.entry().value, base64String);
+          this.updateCurrentValue(this.reactiveEntry(), base64String);
         }
-      }
+      };
       reader.readAsDataURL(file);
-
     }
   }
 }

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
@@ -10,7 +10,18 @@ import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'entry-file-editor',
-  imports: [CommonModule, MatFormField, MatLabel, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule, MatHint],
+  imports: [
+    CommonModule,
+    MatFormField,
+    MatLabel,
+    FormsModule,
+    MatError,
+    ReactiveFormsModule,
+    MatInputModule,
+    MatIconButton,
+    MatIconModule,
+    MatHint
+  ],
   templateUrl: './file-editor.html',
   styleUrl: './file-editor.scss',
 })
@@ -33,15 +44,13 @@ export class FileEditor {
   }
 
   private initialize(re: ReactiveEntry) {
-    const entry = re.entry();
     const validators = this.setupValidators(re);
     this.inputFormControl = this.setupFormControl(re, validators);
-    this.readOnly = entry.value?.isReadOnly;
+    this.readOnly = re.value.isReadOnly;
   }
 
   private updateCurrentValue(re: ReactiveEntry, value: any) {
-    const entry = re.entry();
-    re.setCurrent(value ?? entry.value?.default);
+    re.setCurrentValue(value ?? re.value.default);
   }
 
   disableInputFormControl(control: UntypedFormControl, disable: boolean) {
@@ -52,22 +61,21 @@ export class FileEditor {
   }
 
   setupValidators(re: ReactiveEntry): ValidatorFn[] {
-    const entry = re.entry();
     let validators = [] as ValidatorFn[];
-    if (entry.validation?.isRequired)
+    if (re.validation?.isRequired)
       validators.push(Validators.required);
 
     return validators;
   }
 
   private setupFormControl(re: ReactiveEntry, validators: ValidatorFn[]): UntypedFormControl {
-    const entry = re.entry();
-    const initial = entry.value?.current ?? '';
+    const entryValue = re.value;
+    const initial = entryValue.current ?? '';
 
     const ctrl = new UntypedFormControl(
       {
         value: initial,
-        disabled: this.disabled() || (entry.value.isReadOnly ?? false) || entry.value?.type === EntryValueType.Stream,
+        disabled: this.disabled() || (entryValue.isReadOnly ?? false) || entryValue?.type === EntryValueType.Stream,
       },
       validators
     );

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
@@ -1,12 +1,12 @@
 <!-- SLIDER -->
 @if (shouldUseSlider() && !useTextArea()) {
   <div class="slider-wrap">
-    <label class="slider-label">{{ entry().displayName }}</label>
+    <label class="slider-label">{{ reactiveEntry().displayName }}</label>
     <div class="slider-row">
       <mat-slider
         class="entry-slider"
-        [min]="entry().validation?.minimum"
-        [max]="entry().validation?.maximum"
+        [min]="reactiveEntry().validation?.minimum"
+        [max]="reactiveEntry().validation?.maximum"
         [step]="getSliderStep()"
         [discrete]="!shouldShowInlineInput()"
         [disabled]="inputFormControl.disabled"
@@ -15,7 +15,7 @@
           matSliderThumb
           [ngModel]="
           inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-            ? entry().validation?.minimum ?? 0
+            ? reactiveEntry().validation?.minimum ?? 0
             : +inputFormControl.value
         "
           (ngModelChange)="inputFormControl.setValue($event)" />
@@ -26,13 +26,13 @@
             matInput
             type="number"
             [step]="getSliderStep()"
-            [min]="entry().validation?.minimum!"
-            [max]="entry().validation?.maximum!"
+            [min]="reactiveEntry().validation?.minimum!"
+            [max]="reactiveEntry().validation?.maximum!"
             [formControl]="inputFormControl"
             [readonly]="readOnly()"
             [placeholder]="
           inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-            ? entry().value.default ?? ''
+            ? reactiveEntry().value.default ?? ''
             : ''
         " />
         </mat-form-field>
@@ -41,16 +41,16 @@
   </div>
 } @else {
   <mat-form-field class="full-width-input entry-form-field" appearance="outline">
-    <mat-label>{{ entry().displayName }}</mat-label>
+    <mat-label>{{ reactiveEntry().displayName }}</mat-label>
     @if (!useTextArea()) {
       <input
         aria-label="Text field for changing an entry value."
         [type]="isPassword ? 'password' : isNumber ? 'number' : 'text'"
-        [attr.min]="isNumber ? entry().validation?.minimum : null"
-        [attr.max]="isNumber ? entry().validation?.maximum : null"
+        [attr.min]="isNumber ? reactiveEntry().validation?.minimum : null"
+        [attr.max]="isNumber ? reactiveEntry().validation?.maximum : null"
         [placeholder]="
         inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-          ? entry().value.default ?? ''
+          ? reactiveEntry().value.default ?? ''
           : ''
       "
         [readonly]="readOnly()"
@@ -58,28 +58,28 @@
         [formControl]="inputFormControl" />
     }
     <mat-hint
-      [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
+      [ngClass]="{ 'entry-editor-disabled': disabled() || (reactiveEntry().value.isReadOnly ?? false) }"
       class="truncate">
-      {{ entry().description }}
+      {{ reactiveEntry().description }}
     </mat-hint>
     @if (inputFormControl.hasError('min')) {
       <mat-error class="truncate">
-        Please enter a value higher than {{ entry().validation?.minimum }}
+        Please enter a value higher than {{ reactiveEntry().validation?.minimum }}
       </mat-error>
     }
     @if (inputFormControl.hasError('max')) {
       <mat-error class="truncate">
-        Please enter a value lower than {{ entry().validation?.maximum }}
+        Please enter a value lower than {{ reactiveEntry().validation?.maximum }}
       </mat-error>
     }
     @if (inputFormControl.hasError('pattern')) {
       <mat-error class="truncate">
-        Please make sure your input matches the pattern: {{ entry().validation?.regex }}
+        Please make sure your input matches the pattern: {{ reactiveEntry().validation?.regex }}
       </mat-error>
     }
     @if (inputFormControl.hasError('required')) {
       <mat-error class="truncate">
-        {{ entry().displayName }} is <strong>required</strong>
+        {{ reactiveEntry().displayName }} is <strong>required</strong>
       </mat-error>
     }
     @if (inputFormControl.hasError('invalidEntryValue')) {
@@ -93,7 +93,7 @@
         matInput
         [placeholder]="
         inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-          ? entry().value.default ?? ''
+          ? reactiveEntry().value.default ?? ''
           : ''
       "
         rows="5"

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
@@ -57,11 +57,11 @@ export class InputEditor implements OnDestroy {
   }
 
   private initialize(re: ReactiveEntry) {
-    const entry = re.entry();
+    const entryValue = re.value;
     this.readOnly.set(
-      entry.value?.isReadOnly || this.isSinglePossibleValue(re) || entry.value.type === EntryValueType.Exception
+      entryValue.isReadOnly || this.isSinglePossibleValue(re) || entryValue.type === EntryValueType.Exception
     );
-    this.updateCurrentValue(re, entry.value.current);
+    this.updateCurrentValue(re, entryValue.current);
     this.determineInputType(re);
 
     const validators = this.setupValidators(re);
@@ -69,11 +69,12 @@ export class InputEditor implements OnDestroy {
   }
 
   private updateCurrentValue(re: ReactiveEntry, value: any) {
-    const entry = re.entry();
+    const entryValue = re.value;
     const newValue = this.isSinglePossibleValue(re)
-      ? (entry.value.possible?.[0]?.key ?? '')
-      : value ?? entry.value?.default;
-    re.setCurrent(newValue);
+      ? (entryValue.possible?.[0]?.key ?? '')
+      : value ?? entryValue.default;
+
+    re.setCurrentValue(newValue);
   }
 
   isSinglePossibleValue(re: ReactiveEntry): boolean {
@@ -82,27 +83,37 @@ export class InputEditor implements OnDestroy {
   }
 
   disableInputFormControl(control: UntypedFormControl, disable: boolean) {
-    if (disable) control.disable();
-    else control.enable();
+    if (disable) {
+      control.disable();
+    }
+    else {
+      control.enable();
+    }
   }
 
   setupValidators(re: ReactiveEntry): ValidatorFn[] {
-    const entry = re.entry();
-    var validators = [] as ValidatorFn[];
-    validators.push(invalidEntryValueValidator(entry.value.type));
-    if (entry.validation?.isRequired) validators.push(Validators.required);
-    if (this.isNumber) this.addNumberValidators(validators, re);
-    else this.addTextValidators(validators, re);
+    let validators = [] as ValidatorFn[];
+    validators.push(invalidEntryValueValidator(re.value.type));
+
+    if (re.validation?.isRequired) {
+      validators.push(Validators.required);
+    }
+
+    if (this.isNumber) {
+      this.addNumberValidators(validators, re);
+    } else {
+      this.addTextValidators(validators, re);
+    }
 
     return validators;
   }
 
   private setupFormControl(re: ReactiveEntry, validators: ValidatorFn[]): UntypedFormControl {
-    const entry = re.entry();
+    const entryValue = re.value;
     const result = new UntypedFormControl(
       {
-        value: entry.value?.current ?? entry.value?.default ?? '',
-        disabled: this.disabled() || (entry.value.isReadOnly ?? false),
+        value: entryValue.current ?? entryValue.default ?? '',
+        disabled: this.disabled() || (entryValue.isReadOnly ?? false),
       },
       validators
     );
@@ -128,15 +139,14 @@ export class InputEditor implements OnDestroy {
   }
 
   addNumberValidators(validators: ValidatorFn[], re: ReactiveEntry) {
-    const entry = re.entry();
-    var typeSpecificMaximum = this.getTypeSpecificMaximum(entry.value?.type);
-    var typeSpecificMinimum = this.getTypeSpecificMinimum(entry.value?.type);
+    const typeSpecificMaximum = this.getTypeSpecificMaximum(re.value.type);
+    const typeSpecificMinimum = this.getTypeSpecificMinimum(re.value.type);
 
     validators.push(
-      maxEntryValueValidator(Math.min(typeSpecificMaximum, entry.validation?.maximum ?? typeSpecificMaximum))
+      maxEntryValueValidator(Math.min(typeSpecificMaximum, re.validation?.maximum ?? typeSpecificMaximum))
     );
     validators.push(
-      minEntryValueValidator(Math.max(typeSpecificMinimum, entry.validation?.minimum ?? typeSpecificMinimum))
+      minEntryValueValidator(Math.max(typeSpecificMinimum, re.validation?.minimum ?? typeSpecificMinimum))
     );
   }
 
@@ -216,10 +226,16 @@ export class InputEditor implements OnDestroy {
   }
 
   private defaultSliderCheck(re: ReactiveEntry): boolean {
-    if (!this.isNumber) return false;
+    if (!this.isNumber) {
+      return false;
+    }
+
     const min = re.validation?.minimum;
     const max = re.validation?.maximum;
-    if (min == null || max == null) return false;
+
+    if (min == null || max == null) {
+      return false;
+    }
 
     const typeMin = this.getTypeSpecificMinimum(re.value.type);
     const typeMax = this.getTypeSpecificMaximum(re.value.type);
@@ -241,6 +257,7 @@ export class InputEditor implements OnDestroy {
     const re = this.reactiveEntry();
     const min = re.validation?.minimum ?? 0;
     const max = re.validation?.maximum ?? 0;
+
     return max - min;
   }
 
@@ -248,6 +265,7 @@ export class InputEditor implements OnDestroy {
     const re = this.reactiveEntry();
     const minAbs = Math.abs(re.validation?.minimum ?? 0);
     const maxAbs = Math.abs(re.validation?.maximum ?? 0);
+
     return Math.max(minAbs, maxAbs).toString().length;
   }
 

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
@@ -1,7 +1,7 @@
-import { Component, effect, input, model, OnDestroy, signal } from '@angular/core';
+import { Component, effect, input, OnDestroy, signal } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl, ValidatorFn, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { Entry } from '../models/entry';
+import { ReactiveEntry } from '../reactive-entry';
 import { EntryUnitType } from '../models/entry-unit-type';
 import { EntryValueType } from '../models/entry-value-type';
 import {
@@ -10,7 +10,6 @@ import {
   minEntryValueValidator,
 } from '../validators/entry-editor.validators';
 import { CommonModule } from '@angular/common';
-import { EntryValue } from '../models/entry-value';
 import { MatError, MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
@@ -42,13 +41,13 @@ export class InputEditor implements OnDestroy {
   useTextArea = signal(false);
   readOnly = signal<boolean>(false);
   disabled = input<boolean>(false);
-  entry = model.required<Entry>();
+  reactiveEntry = input.required<ReactiveEntry>();
   private readonly INLINE_INPUT_RANGE_THRESHOLD = 100;
 
   constructor() {
     this.inputFormControl = new UntypedFormControl();
     const reference = effect(() => {
-      this.initialize(this.entry());
+      this.initialize(this.reactiveEntry());
       reference.destroy();
     });
 
@@ -57,29 +56,28 @@ export class InputEditor implements OnDestroy {
     });
   }
 
-  private initialize(entry: Entry) {
+  private initialize(re: ReactiveEntry) {
+    const entry = re.entry();
     this.readOnly.set(
-      entry.value?.isReadOnly || this.isSinglePossibleValue(entry) || entry.value.type === EntryValueType.Exception
+      entry.value?.isReadOnly || this.isSinglePossibleValue(re) || entry.value.type === EntryValueType.Exception
     );
-    this.updateCurrentValue(entry.value, entry.value.current);
-    this.determineInputType();
+    this.updateCurrentValue(re, entry.value.current);
+    this.determineInputType(re);
 
-    const validators = this.setupValidators(entry);
-    this.inputFormControl = this.setupFormControl(entry, validators);
+    const validators = this.setupValidators(re);
+    this.inputFormControl = this.setupFormControl(re, validators);
   }
 
-  private updateCurrentValue(currentValue: EntryValue, value: any) {
-    this.entry.update(e => {
-      let copy = Object.assign({}, e);
-      copy.value.current = this.isSinglePossibleValue(e)
-        ? (e.value.possible?.[0]?.key ?? '')
-        : value ?? currentValue?.default;
-      return copy;
-    });
+  private updateCurrentValue(re: ReactiveEntry, value: any) {
+    const entry = re.entry();
+    const newValue = this.isSinglePossibleValue(re)
+      ? (entry.value.possible?.[0]?.key ?? '')
+      : value ?? entry.value?.default;
+    re.setCurrent(newValue);
   }
 
-  isSinglePossibleValue(entry: Entry): boolean {
-    const result = entry.value.possible && entry.value.possible.length === 1;
+  isSinglePossibleValue(re: ReactiveEntry): boolean {
+    const result = re.value.possible && re.value.possible.length === 1;
     return result ?? false;
   }
 
@@ -88,17 +86,19 @@ export class InputEditor implements OnDestroy {
     else control.enable();
   }
 
-  setupValidators(entry: Entry): ValidatorFn[] {
+  setupValidators(re: ReactiveEntry): ValidatorFn[] {
+    const entry = re.entry();
     var validators = [] as ValidatorFn[];
     validators.push(invalidEntryValueValidator(entry.value.type));
     if (entry.validation?.isRequired) validators.push(Validators.required);
-    if (this.isNumber) this.addNumberValidators(validators);
-    else this.addTextValidators(validators);
+    if (this.isNumber) this.addNumberValidators(validators, re);
+    else this.addTextValidators(validators, re);
 
     return validators;
   }
 
-  private setupFormControl(entry: Entry, validators: ValidatorFn[]): UntypedFormControl {
+  private setupFormControl(re: ReactiveEntry, validators: ValidatorFn[]): UntypedFormControl {
+    const entry = re.entry();
     const result = new UntypedFormControl(
       {
         value: entry.value?.current ?? entry.value?.default ?? '',
@@ -109,7 +109,7 @@ export class InputEditor implements OnDestroy {
 
     this.formControlSubscription = result.valueChanges.subscribe(value => {
       if (result.status == 'VALID') {
-        this.updateCurrentValue(this.entry().value, value);
+        this.updateCurrentValue(this.reactiveEntry(), value);
       }
     });
 
@@ -120,22 +120,23 @@ export class InputEditor implements OnDestroy {
     this.formControlSubscription?.unsubscribe();
   }
 
-  addTextValidators(validators: ValidatorFn[]) {
-    const regex = this.entry().validation?.regex;
+  addTextValidators(validators: ValidatorFn[], re: ReactiveEntry) {
+    const regex = re.validation?.regex;
     if (regex) {
       validators.push(Validators.pattern(regex));
     }
   }
 
-  addNumberValidators(validators: ValidatorFn[]) {
-    var typeSpecificMaximum = this.getTypeSpecificMaximum(this.entry().value?.type);
-    var typeSpecificMinimum = this.getTypeSpecificMinimum(this.entry().value?.type);
+  addNumberValidators(validators: ValidatorFn[], re: ReactiveEntry) {
+    const entry = re.entry();
+    var typeSpecificMaximum = this.getTypeSpecificMaximum(entry.value?.type);
+    var typeSpecificMinimum = this.getTypeSpecificMinimum(entry.value?.type);
 
     validators.push(
-      maxEntryValueValidator(Math.min(typeSpecificMaximum, this.entry().validation?.maximum ?? typeSpecificMaximum))
+      maxEntryValueValidator(Math.min(typeSpecificMaximum, entry.validation?.maximum ?? typeSpecificMaximum))
     );
     validators.push(
-      minEntryValueValidator(Math.max(typeSpecificMinimum, this.entry().validation?.minimum ?? typeSpecificMinimum))
+      minEntryValueValidator(Math.max(typeSpecificMinimum, entry.validation?.minimum ?? typeSpecificMinimum))
     );
   }
 
@@ -189,20 +190,21 @@ export class InputEditor implements OnDestroy {
     }
   }
 
-  determineInputType() {
+  determineInputType(re: ReactiveEntry) {
+    const value = re.value;
     if (
-      EntryValueType.Int16 === this.entry().value?.type ||
-      EntryValueType.UInt16 === this.entry().value?.type ||
-      EntryValueType.Int32 === this.entry().value?.type ||
-      EntryValueType.UInt32 === this.entry().value?.type ||
-      EntryValueType.Int64 === this.entry().value?.type ||
-      EntryValueType.UInt64 === this.entry().value?.type ||
-      EntryValueType.Single === this.entry().value?.type ||
-      EntryValueType.Double === this.entry().value?.type ||
-      EntryValueType.Byte === this.entry().value?.type
+      EntryValueType.Int16 === value?.type ||
+      EntryValueType.UInt16 === value?.type ||
+      EntryValueType.Int32 === value?.type ||
+      EntryValueType.UInt32 === value?.type ||
+      EntryValueType.Int64 === value?.type ||
+      EntryValueType.UInt64 === value?.type ||
+      EntryValueType.Single === value?.type ||
+      EntryValueType.Double === value?.type ||
+      EntryValueType.Byte === value?.type
     )
       this.isNumber = true;
-    else if (EntryUnitType.Password === this.entry().value?.unitType) this.isPassword = true;
+    else if (EntryUnitType.Password === value?.unitType) this.isPassword = true;
   }
 
   setTextArea(value: boolean) {
@@ -210,23 +212,23 @@ export class InputEditor implements OnDestroy {
   }
 
   shouldUseSlider(): boolean {
-    return this.defaultSliderCheck(this.entry());
+    return this.defaultSliderCheck(this.reactiveEntry());
   }
 
-  private defaultSliderCheck(entryData: Entry): boolean {
+  private defaultSliderCheck(re: ReactiveEntry): boolean {
     if (!this.isNumber) return false;
-    const min = entryData.validation?.minimum;
-    const max = entryData.validation?.maximum;
+    const min = re.validation?.minimum;
+    const max = re.validation?.maximum;
     if (min == null || max == null) return false;
 
-    const typeMin = this.getTypeSpecificMinimum(entryData.value.type);
-    const typeMax = this.getTypeSpecificMaximum(entryData.value.type);
+    const typeMin = this.getTypeSpecificMinimum(re.value.type);
+    const typeMax = this.getTypeSpecificMaximum(re.value.type);
 
     return min > typeMin || max < typeMax;
   }
 
   getSliderStep(): number {
-    switch (this.entry().value.type) {
+    switch (this.reactiveEntry().value.type) {
       case EntryValueType.Single:
       case EntryValueType.Double:
         return 0.1;
@@ -236,14 +238,16 @@ export class InputEditor implements OnDestroy {
   }
 
   private getRange(): number {
-    const min = this.entry().validation?.minimum ?? 0;
-    const max = this.entry().validation?.maximum ?? 0;
+    const re = this.reactiveEntry();
+    const min = re.validation?.minimum ?? 0;
+    const max = re.validation?.maximum ?? 0;
     return max - min;
   }
 
   private maxDigits(): number {
-    const minAbs = Math.abs(this.entry().validation?.minimum ?? 0);
-    const maxAbs = Math.abs(this.entry().validation?.maximum ?? 0);
+    const re = this.reactiveEntry();
+    const minAbs = Math.abs(re.validation?.minimum ?? 0);
+    const maxAbs = Math.abs(re.validation?.maximum ?? 0);
     return Math.max(minAbs, maxAbs).toString().length;
   }
 

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
@@ -14,7 +14,6 @@
     </div>
   }
 
-
   @if (currentReactiveEntry(); as re) {
     <entry-editor
       [editorId]="editorId()" class="navigation-entries"

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
@@ -1,7 +1,7 @@
 @if(entryInformation(); as entryInfo) {
   @if (entryInfo.entryPath) {
     <div class="navigation-bar">
-      @for (e of entryInfo.entryPath; track e; let isLast = $last) {
+      @for (e of entryInfo.entryPath; track e.identifier; let isLast = $last) {
         <span class="navigation-bar-item" (click)="onNavigateSpecific(e)">
           {{e.displayName}}
         </span>

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
@@ -15,10 +15,10 @@
   }
 
 
-  @if (entryInfo.currentEntry) {
+  @if (currentReactiveEntry(); as re) {
     <entry-editor
       [editorId]="editorId()" class="navigation-entries"
-      [(entry)]="entryInfo.currentEntry"
+      [reactiveEntry]="re"
       [disabled]="disabled()">
     </entry-editor>
   }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -13,7 +13,7 @@ import { EntryEditor } from './entry-editor';
   styleUrl: './navigable-entry-editor.scss',
 })
 export class NavigableEntryEditor implements OnDestroy {
-  private service = inject(NavigableEntryService);
+  private navigableEntryService = inject(NavigableEntryService);
   private route = inject(ActivatedRoute);
   private queryParamSubscription?: Subscription;
 
@@ -30,7 +30,7 @@ export class NavigableEntryEditor implements OnDestroy {
   private _reactiveEntry = signal<ReactiveEntry | null>(null);
 
   // Track which ReactiveEntry instance we haveve seen and its last synced version
-  private lastSyncedRe: ReactiveEntry | null = null;
+  private lastSyncedReactiveEntry: ReactiveEntry | null = null;
   private lastSyncedVersion = 0;
 
   entryInformation = signal<NavigableEntryInformation | undefined>(undefined);
@@ -68,8 +68,8 @@ export class NavigableEntryEditor implements OnDestroy {
       const version = re.version();
 
       // If this is a new ReactiveEntry instance, record it and skip initial sync
-      if (re !== this.lastSyncedRe) {
-        this.lastSyncedRe = re;
+      if (re !== this.lastSyncedReactiveEntry) {
+        this.lastSyncedReactiveEntry = re;
         this.lastSyncedVersion = version;
         return;
       }
@@ -105,7 +105,7 @@ export class NavigableEntryEditor implements OnDestroy {
       return;
     }
 
-    const infos = this.service.entryEditorInformation.get(id);
+    const infos = this.navigableEntryService.entryEditorInformation.get(id);
     if (!infos) {
       return;
     }
@@ -118,39 +118,39 @@ export class NavigableEntryEditor implements OnDestroy {
   }
 
   private findReactiveEntryByPath(entryPath: Entry[]): ReactiveEntry | null {
-    const rootRe = this._reactiveEntry();
-    if (!rootRe || entryPath.length === 0) {
+    const rootReactiveEntry = this._reactiveEntry();
+    if (!rootReactiveEntry || entryPath.length === 0) {
       return null;
     }
 
     // Start from root and traverse down following the path
-    let currentRe = rootRe;
+    let current = rootReactiveEntry;
     for (let i = 1; i < entryPath.length; i++) {
       const pathEntry = entryPath[i];
-      const found = currentRe.subEntries().find(sub => sub.identifier === pathEntry.identifier);
+      const found = current.subEntries().find(sub => sub.identifier === pathEntry.identifier);
       if (!found) {
         return null;
       }
-      currentRe = found;
+      current = found;
     }
-    return currentRe;
+    return current;
   }
 
   private update(entry: Entry, editorId: number) {
     if (editorId !== 0) {
-      this.service.signOut(editorId);
+      this.navigableEntryService.signOut(editorId);
     }
-    editorId = this.service.signIn(entry, this.queryParam());
+    editorId = this.navigableEntryService.signIn(entry, this.queryParam());
     this.editorId.set(editorId);
     this.refreshEntryInformation();
   }
 
   ngOnDestroy(): void {
     this.queryParamSubscription?.unsubscribe();
-    this.service.signOut(this.editorId());
+    this.navigableEntryService.signOut(this.editorId());
   }
 
   onNavigateSpecific(entry: Entry) {
-    this.service.onNavigateToSpecificEntry(this.editorId(), entry);
+    this.navigableEntryService.onNavigateToSpecificEntry(this.editorId(), entry);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -1,4 +1,6 @@
 import { Component, OnDestroy, input, effect, model, signal, untracked, inject, computed } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { Entry } from './models/entry';
 import { ReactiveEntry } from './reactive-entry';
 import { NavigableEntryService, NavigableEntryInformation } from './services/navigable-entry.service';
@@ -12,24 +14,21 @@ import { EntryEditor } from './entry-editor';
 })
 export class NavigableEntryEditor implements OnDestroy {
   private service = inject(NavigableEntryService);
+  private route = inject(ActivatedRoute);
+  private queryParamSubscription?: Subscription;
 
   queryParam = input<string | undefined>(undefined);
   disabled = input.required<boolean>();
   // id of the navigableEditor in order to be able to use several entry editors at the same time
   editorId = signal<number>(0);
 
-  // External API - accepts plain Entry
+  // External API - accepts plain Entry (two-way binding propagates changes)
   entry = model.required<Entry>();
 
-  // Internal reactive wrapper
+  // Internal reactive wrapper (needed for navigation and change propagation)
   private _reactiveEntry = signal<ReactiveEntry | null>(null);
 
   entryInformation = signal<NavigableEntryInformation | undefined>(undefined);
-
-  // Provide ReactiveEntry to template
-  get reactiveEntry(): ReactiveEntry | null {
-    return this._reactiveEntry();
-  }
 
   // Computed: current ReactiveEntry from entry path for the current navigation position
   currentReactiveEntry = computed(() => {
@@ -43,22 +42,56 @@ export class NavigableEntryEditor implements OnDestroy {
   });
 
   constructor() {
+    // Initialize ReactiveEntry when entry changes from outside
     effect(() => {
-      // `this.entry()` is assigned to `entry` to make sure,
-      // updates on it will be tracked and take 'effect'.
       const entry = this.entry();
       untracked(() => {
-        // Convert Entry to ReactiveEntry
         const re = ReactiveEntry.fromEntry(entry);
         this._reactiveEntry.set(re);
         this.update(entry, this.editorId());
+        this.setupQueryParamSubscription();
       });
+    });
+  }
+
+  private setupQueryParamSubscription(): void {
+    const qp = this.queryParam();
+    if (!qp) {
+      return;
+    }
+
+    // Unsubscribe from previous subscription
+    this.queryParamSubscription?.unsubscribe();
+
+    // Subscribe to query param changes to detect navigation
+    this.queryParamSubscription = this.route.queryParams.subscribe(() => {
+      this.refreshEntryInformation();
+    });
+  }
+
+  private refreshEntryInformation(): void {
+    const id = this.editorId();
+    if (id === 0) {
+      return;
+    }
+
+    const infos = this.service.entryEditorInformation.get(id);
+    if (!infos) {
+      return;
+    }
+
+    // Create a new object reference to trigger signal update
+    this.entryInformation.set({
+      entryPath: [...infos.entryPath],
+      currentEntry: infos.currentEntry
     });
   }
 
   private findReactiveEntryByPath(entryPath: Entry[]): ReactiveEntry | null {
     const rootRe = this._reactiveEntry();
-    if (!rootRe || entryPath.length === 0) return null;
+    if (!rootRe || entryPath.length === 0) {
+      return null;
+    }
 
     // Start from root and traverse down following the path
     let currentRe = rootRe;
@@ -79,15 +112,11 @@ export class NavigableEntryEditor implements OnDestroy {
     }
     editorId = this.service.signIn(entry, this.queryParam());
     this.editorId.set(editorId);
-    const infos = this.service.entryEditorInformation.get(editorId);
-
-    if (!infos) {
-      return;
-    }
-    this.entryInformation.set(infos);
+    this.refreshEntryInformation();
   }
 
   ngOnDestroy(): void {
+    this.queryParamSubscription?.unsubscribe();
     this.service.signOut(this.editorId());
   }
 

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -19,17 +19,19 @@ export class NavigableEntryEditor implements OnDestroy {
 
   queryParam = input<string | undefined>(undefined);
   disabled = input.required<boolean>();
-  // id of the navigableEditor in order to be able to use several entry editors at the same time
-  editorId = signal<number>(0);
 
   // External API - accepts plain Entry (two-way binding propagates changes)
   entry = model.required<Entry>();
 
+  // Id of the navigableEditor in order to be able to use several entry editors at the same time
+  editorId = signal<number>(0);
+
   // Internal reactive wrapper (needed for navigation and change propagation)
   private _reactiveEntry = signal<ReactiveEntry | null>(null);
 
-  // Flag to prevent re-initialization loop when syncing changes back
-  private isInternalUpdate = false;
+  // Track which ReactiveEntry instance we haveve seen and its last synced version
+  private lastSyncedRe: ReactiveEntry | null = null;
+  private lastSyncedVersion = 0;
 
   entryInformation = signal<NavigableEntryInformation | undefined>(undefined);
 
@@ -49,10 +51,6 @@ export class NavigableEntryEditor implements OnDestroy {
     effect(() => {
       const entry = this.entry();
       untracked(() => {
-        if (this.isInternalUpdate) {
-          this.isInternalUpdate = false;
-          return;
-        }
         const re = ReactiveEntry.fromEntry(entry);
         this._reactiveEntry.set(re);
         this.update(entry, this.editorId());
@@ -63,25 +61,35 @@ export class NavigableEntryEditor implements OnDestroy {
     // Watch for changes in ReactiveEntry and sync back to entry model
     effect(() => {
       const re = this._reactiveEntry();
-      if (!re) return;
+      if (!re) {
+        return;
+      }
+
+      const version = re.version();
+
+      // If this is a new ReactiveEntry instance, record it and skip initial sync
+      if (re !== this.lastSyncedRe) {
+        this.lastSyncedRe = re;
+        this.lastSyncedVersion = version;
+        return;
+      }
+
+      // Only sync when version has increased (actual mutation occurred)
+      if (version <= this.lastSyncedVersion) return;
 
       // Read the changed signal - this creates the dependency
       const changedEntry = re.changed();
 
       untracked(() => {
+        // Track that we've synced this version
+        this.lastSyncedVersion = version;
         // Sync back to entry model
-        this.isInternalUpdate = true;
         this.entry.set(changedEntry);
       });
     });
   }
 
   private setupQueryParamSubscription(): void {
-    const qp = this.queryParam();
-    if (!qp) {
-      return;
-    }
-
     // Unsubscribe from previous subscription
     this.queryParamSubscription?.unsubscribe();
 

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -28,6 +28,9 @@ export class NavigableEntryEditor implements OnDestroy {
   // Internal reactive wrapper (needed for navigation and change propagation)
   private _reactiveEntry = signal<ReactiveEntry | null>(null);
 
+  // Flag to prevent re-initialization loop when syncing changes back
+  private isInternalUpdate = false;
+
   entryInformation = signal<NavigableEntryInformation | undefined>(undefined);
 
   // Computed: current ReactiveEntry from entry path for the current navigation position
@@ -46,10 +49,29 @@ export class NavigableEntryEditor implements OnDestroy {
     effect(() => {
       const entry = this.entry();
       untracked(() => {
+        if (this.isInternalUpdate) {
+          this.isInternalUpdate = false;
+          return;
+        }
         const re = ReactiveEntry.fromEntry(entry);
         this._reactiveEntry.set(re);
         this.update(entry, this.editorId());
         this.setupQueryParamSubscription();
+      });
+    });
+
+    // Watch for changes in ReactiveEntry and sync back to entry model
+    effect(() => {
+      const re = this._reactiveEntry();
+      if (!re) return;
+
+      // Read the changed signal - this creates the dependency
+      const changedEntry = re.changed();
+
+      untracked(() => {
+        // Sync back to entry model
+        this.isInternalUpdate = true;
+        this.entry.set(changedEntry);
       });
     });
   }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -1,6 +1,7 @@
-import { Component, OnDestroy, input, effect, model, signal, untracked, inject } from '@angular/core';
+import { Component, OnDestroy, input, effect, model, signal, untracked, inject, computed } from '@angular/core';
 import { Entry } from './models/entry';
-import { NavigableEntryInformation, NavigableEntryService } from './services/navigable-entry.service';
+import { ReactiveEntry } from './reactive-entry';
+import { NavigableEntryService, NavigableEntryInformation } from './services/navigable-entry.service';
 import { EntryEditor } from './entry-editor';
 
 @Component({
@@ -14,23 +15,62 @@ export class NavigableEntryEditor implements OnDestroy {
 
   queryParam = input<string | undefined>(undefined);
   disabled = input.required<boolean>();
-  //id of the navigableEditor in order to be able to use several entry editors at the same time
+  // id of the navigableEditor in order to be able to use several entry editors at the same time
   editorId = signal<number>(0);
 
+  // External API - accepts plain Entry
   entry = model.required<Entry>();
 
+  // Internal reactive wrapper
+  private _reactiveEntry = signal<ReactiveEntry | null>(null);
+
   entryInformation = signal<NavigableEntryInformation | undefined>(undefined);
+
+  // Provide ReactiveEntry to template
+  get reactiveEntry(): ReactiveEntry | null {
+    return this._reactiveEntry();
+  }
+
+  // Computed: current ReactiveEntry from entry path for the current navigation position
+  currentReactiveEntry = computed(() => {
+    const info = this.entryInformation();
+    if (!info?.currentEntry) {
+      return null;
+    }
+
+    // Find the ReactiveEntry that corresponds to the current navigation entry
+    return this.findReactiveEntryByPath(info.entryPath);
+  });
 
   constructor() {
     effect(() => {
       // `this.entry()` is assigned to `entry` to make sure,
       // updates on it will be tracked and take 'effect'.
-
-      const entry = Object.assign(this.entry());
+      const entry = this.entry();
       untracked(() => {
+        // Convert Entry to ReactiveEntry
+        const re = ReactiveEntry.fromEntry(entry);
+        this._reactiveEntry.set(re);
         this.update(entry, this.editorId());
       });
     });
+  }
+
+  private findReactiveEntryByPath(entryPath: Entry[]): ReactiveEntry | null {
+    const rootRe = this._reactiveEntry();
+    if (!rootRe || entryPath.length === 0) return null;
+
+    // Start from root and traverse down following the path
+    let currentRe = rootRe;
+    for (let i = 1; i < entryPath.length; i++) {
+      const pathEntry = entryPath[i];
+      const found = currentRe.subEntries().find(sub => sub.identifier === pathEntry.identifier);
+      if (!found) {
+        return null;
+      }
+      currentRe = found;
+    }
+    return currentRe;
   }
 
   private update(entry: Entry, editorId: number) {
@@ -41,7 +81,9 @@ export class NavigableEntryEditor implements OnDestroy {
     this.editorId.set(editorId);
     const infos = this.service.entryEditorInformation.get(editorId);
 
-    if (!infos) return;
+    if (!infos) {
+      return;
+    }
     this.entryInformation.set(infos);
   }
 

--- a/projects/ngx-web-framework/entry-editor/reactive-entry.ts
+++ b/projects/ngx-web-framework/entry-editor/reactive-entry.ts
@@ -8,7 +8,7 @@ export class ReactiveEntry {
   private readonly _entry: WritableSignal<Entry>;
 
   // Mutable property signals (only these need reactive tracking)
-  private readonly _current: WritableSignal<string | null | undefined>;
+  private readonly _currentValue: WritableSignal<string | null | undefined>;
   private readonly _subEntries: WritableSignal<ReactiveEntry[]>;
 
   // Parent reference for change propagation
@@ -20,7 +20,7 @@ export class ReactiveEntry {
   constructor(entry: Entry, parent?: ReactiveEntry) {
     this._version = signal(0);
     this._entry = signal(structuredClone(entry));
-    this._current = signal(entry.value?.current);
+    this._currentValue = signal(entry.value?.current);
     this._subEntries = signal(
       (entry.subEntries ?? []).map(sub => new ReactiveEntry(sub, this))
     );
@@ -30,8 +30,8 @@ export class ReactiveEntry {
   // Readable signals for mutable properties
 
   /** The current editable value - reactive */
-  readonly current: Signal<string | null | undefined> =
-    computed(() => this._current());
+  readonly currentValue: Signal<string | null | undefined> =
+    computed(() => this._currentValue());
 
   /** Sub-entries as ReactiveEntry array - reactive */
   readonly subEntries: Signal<ReactiveEntry[]> =
@@ -49,44 +49,40 @@ export class ReactiveEntry {
    */
   readonly version: Signal<number> = computed(() => this._version());
 
-  // Non-signal accessors for read-only properties
-
-  /** Access underlying Entry for read-only properties */
-  entry(): Entry {
-    return this._entry();
-  }
-
   // Convenience getters for common read-only properties
 
-  get displayName(): string | null | undefined {
-    return this._entry().displayName;
+  get displayName(): string | null {
+    return this._entry().displayName ?? null;
   }
 
-  get description(): string | null | undefined {
-    return this._entry().description;
+  get description(): string | null {
+    return this._entry().description ?? null;
   }
 
-  get identifier(): string | null | undefined {
-    return this._entry().identifier;
+  get identifier(): string  {
+    // Hint identifier is generated as optional, so we enforce it here for convenience
+    return this._entry().identifier!;
   }
 
   get value(): EntryValue {
     return this._entry().value;
   }
 
-  get validation(): EntryValidation | undefined {
-    return this._entry().validation;
+  get validation(): EntryValidation {
+    // Hint validation is generated as optional, so we enforce it here for convenience
+    return this._entry().validation!;
   }
 
-  get prototypes(): Array<Entry> | null | undefined {
-    return this._entry().prototypes;
+  get prototypes(): Entry[] {
+    // Hint prototypes is generated as optional, so we enforce it here for convenience
+    return this._entry().prototypes!;
   }
 
   // mutation methods
 
   /** Update the current value */
-  setCurrent(value: string | null | undefined): void {
-    this._current.set(value);
+  setCurrentValue(value: string | null | undefined): void {
+    this._currentValue.set(value);
     this._entry.update(e => ({
       ...e,
       value: { ...e.value, current: value }
@@ -125,7 +121,7 @@ export class ReactiveEntry {
   /** Replace entry completely (for type switching) */
   replaceEntry(entry: Entry): void {
     this._entry.set(structuredClone(entry));
-    this._current.set(entry.value?.current);
+    this._currentValue.set(entry.value.current);
     this._subEntries.set(
       (entry.subEntries ?? []).map(sub => new ReactiveEntry(sub, this))
     );
@@ -139,7 +135,7 @@ export class ReactiveEntry {
     const base = this._entry();
     return {
       ...base,
-      value: { ...base.value, current: this._current() },
+      value: { ...base.value, current: this._currentValue() },
       subEntries: this._subEntries().map(re => re.toEntry())
     };
   }

--- a/projects/ngx-web-framework/entry-editor/reactive-entry.ts
+++ b/projects/ngx-web-framework/entry-editor/reactive-entry.ts
@@ -33,6 +33,12 @@ export class ReactiveEntry {
   readonly subEntries: Signal<ReactiveEntry[]> =
     computed(() => this._subEntries());
 
+  /**
+   * Signal that emits the current Entry whenever any change occurs.
+   * Watch this to detect modifications to the entry tree.
+   */
+  readonly changed: Signal<Entry> = computed(() => this.toEntry());
+
   // Non-signal accessors for read-only properties
 
   /** Access underlying Entry for read-only properties */

--- a/projects/ngx-web-framework/entry-editor/reactive-entry.ts
+++ b/projects/ngx-web-framework/entry-editor/reactive-entry.ts
@@ -14,7 +14,11 @@ export class ReactiveEntry {
   // Parent reference for change propagation
   private readonly _parent: ReactiveEntry | null = null;
 
+  // Version counter - increments on each mutation (used to detect actual changes vs initial state)
+  private readonly _version: WritableSignal<number>;
+
   constructor(entry: Entry, parent?: ReactiveEntry) {
+    this._version = signal(0);
     this._entry = signal(structuredClone(entry));
     this._current = signal(entry.value?.current);
     this._subEntries = signal(
@@ -38,6 +42,12 @@ export class ReactiveEntry {
    * Watch this to detect modifications to the entry tree.
    */
   readonly changed: Signal<Entry> = computed(() => this.toEntry());
+
+  /**
+   * Version counter that increments on each mutation.
+   * Use this to distinguish initial state (version 0) from actual changes (version > 0).
+   */
+  readonly version: Signal<number> = computed(() => this._version());
 
   // Non-signal accessors for read-only properties
 
@@ -152,6 +162,9 @@ export class ReactiveEntry {
     if (this._parent) {
       this._parent.syncSubEntries();
       this._parent.notifyParent();
+    } else {
+      // At root level - increment version to signal a change occurred
+      this._version.update(v => v + 1);
     }
   }
 }

--- a/projects/ngx-web-framework/entry-editor/reactive-entry.ts
+++ b/projects/ngx-web-framework/entry-editor/reactive-entry.ts
@@ -1,0 +1,151 @@
+import { signal, computed, Signal, WritableSignal } from '@angular/core';
+import { Entry } from './models/entry';
+import { EntryValidation } from './models/entry-validation';
+import { EntryValue } from './models/entry-value';
+
+export class ReactiveEntry {
+  // Core signal holding the Entry - ALL reads go through this
+  private readonly _entry: WritableSignal<Entry>;
+
+  // Mutable property signals (only these need reactive tracking)
+  private readonly _current: WritableSignal<string | null | undefined>;
+  private readonly _subEntries: WritableSignal<ReactiveEntry[]>;
+
+  // Parent reference for change propagation
+  private readonly _parent: ReactiveEntry | null = null;
+
+  constructor(entry: Entry, parent?: ReactiveEntry) {
+    this._entry = signal(structuredClone(entry));
+    this._current = signal(entry.value?.current);
+    this._subEntries = signal(
+      (entry.subEntries ?? []).map(sub => new ReactiveEntry(sub, this))
+    );
+    this._parent = parent ?? null;
+  }
+
+  // Readable signals for mutable properties
+
+  /** The current editable value - reactive */
+  readonly current: Signal<string | null | undefined> =
+    computed(() => this._current());
+
+  /** Sub-entries as ReactiveEntry array - reactive */
+  readonly subEntries: Signal<ReactiveEntry[]> =
+    computed(() => this._subEntries());
+
+  // Non-signal accessors for read-only properties
+
+  /** Access underlying Entry for read-only properties */
+  entry(): Entry {
+    return this._entry();
+  }
+
+  // Convenience getters for common read-only properties
+
+  get displayName(): string | null | undefined {
+    return this._entry().displayName;
+  }
+
+  get description(): string | null | undefined {
+    return this._entry().description;
+  }
+
+  get identifier(): string | null | undefined {
+    return this._entry().identifier;
+  }
+
+  get value(): EntryValue {
+    return this._entry().value;
+  }
+
+  get validation(): EntryValidation | undefined {
+    return this._entry().validation;
+  }
+
+  get prototypes(): Array<Entry> | null | undefined {
+    return this._entry().prototypes;
+  }
+
+  // mutation methods
+
+  /** Update the current value */
+  setCurrent(value: string | null | undefined): void {
+    this._current.set(value);
+    this._entry.update(e => ({
+      ...e,
+      value: { ...e.value, current: value }
+    }));
+    this.notifyParent();
+  }
+
+  /** Add a sub-entry */
+  addSubEntry(entry: Entry): ReactiveEntry {
+    const reactive = new ReactiveEntry(entry, this);
+    this._subEntries.update(subs => [...subs, reactive]);
+    this.syncSubEntries();
+    this.notifyParent();
+    return reactive;
+  }
+
+  /** Remove a sub-entry by identifier */
+  removeSubEntry(identifier: string): boolean {
+    const subs = this._subEntries();
+    const index = subs.findIndex(s => s.identifier === identifier);
+    if (index === -1) return false;
+
+    this._subEntries.update(arr => arr.filter((_, i) => i !== index));
+    this.syncSubEntries();
+    this.notifyParent();
+    return true;
+  }
+
+  /** Clear all sub-entries */
+  clearSubEntries(): void {
+    this._subEntries.set([]);
+    this.syncSubEntries();
+    this.notifyParent();
+  }
+
+  /** Replace entry completely (for type switching) */
+  replaceEntry(entry: Entry): void {
+    this._entry.set(structuredClone(entry));
+    this._current.set(entry.value?.current);
+    this._subEntries.set(
+      (entry.subEntries ?? []).map(sub => new ReactiveEntry(sub, this))
+    );
+    this.notifyParent();
+  }
+
+  // Conversion to ReactiveEntry and back
+
+  /** Convert back to plain Entry (for API calls) */
+  toEntry(): Entry {
+    const base = this._entry();
+    return {
+      ...base,
+      value: { ...base.value, current: this._current() },
+      subEntries: this._subEntries().map(re => re.toEntry())
+    };
+  }
+
+  /** Factory method */
+  static fromEntry(entry: Entry): ReactiveEntry {
+    return new ReactiveEntry(entry);
+  }
+
+  // privates
+
+  private syncSubEntries(): void {
+    this._entry.update(e => ({
+      ...e,
+      subEntries: this._subEntries().map(re => re.toEntry())
+    }));
+  }
+
+  private notifyParent(): void {
+    if (this._parent) {
+      this._parent.syncSubEntries();
+      this._parent.notifyParent();
+    }
+  }
+}


### PR DESCRIPTION
- EntryEditor was working on Entry-model which does not work in zoneless environment
- Reworked to use signals for changing values and implemented proper update mechanism to the underlying model
- Entry is now wrapped in ReactiveEntry (type of view-model) with change tracking
  - only chaning values are exported as signals
  - not changing values are exported as property