### PR TITLE
Removed added suppressions after migration

### DIFF
--- a/projects/moryx-demo/tsconfig.app.json
+++ b/projects/moryx-demo/tsconfig.app.json
@@ -11,13 +11,5 @@
   ],
   "exclude": [
     "src/**/*.spec.ts"
-  ],
-  "angularCompilerOptions": {
-    "extendedDiagnostics": {
-      "checks": {
-        "nullishCoalescingNotNullable": "suppress",
-        "optionalChainNotNullable": "suppress"
-      }
-    }
-  }
+  ]
 }

--- a/projects/ngx-web-framework/tsconfig.lib.json
+++ b/projects/ngx-web-framework/tsconfig.lib.json
@@ -19,13 +19,5 @@
   ],
   "exclude": [
     "**/*.spec.ts"
-  ],
-  "angularCompilerOptions": {
-    "extendedDiagnostics": {
-      "checks": {
-        "nullishCoalescingNotNullable": "suppress",
-        "optionalChainNotNullable": "suppress"
-      }
-    }
-  }
+  ]
 }

--- a/projects/ngx-web-framework/tsconfig.lib.prod.json
+++ b/projects/ngx-web-framework/tsconfig.lib.prod.json
@@ -6,12 +6,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "compilationMode": "partial",
-    "extendedDiagnostics": {
-      "checks": {
-        "nullishCoalescingNotNullable": "suppress",
-        "optionalChainNotNullable": "suppress"
-      }
-    }
+    "compilationMode": "partial"
   }
 }

--- a/projects/ngx-web-framework/tsconfig.spec.json
+++ b/projects/ngx-web-framework/tsconfig.spec.json
@@ -11,13 +11,5 @@
   "include": [
     "src/**/*.d.ts",
     "src/**/*.spec.ts"
-  ],
-  "angularCompilerOptions": {
-    "extendedDiagnostics": {
-      "checks": {
-        "nullishCoalescingNotNullable": "suppress",
-        "optionalChainNotNullable": "suppress"
-      }
-    }
-  }
+  ]
 }


### PR DESCRIPTION
As described in [this article](https://blog.ninja-squad.com/2026/06/03/what-is-new-angular-22.0) the suppressions were added automatically. Removed them, no issues.

@1nf0rmagician merge instantly after approval