### PR TITLE
Added interceptor fns als replacement for interceptors

### DIFF
--- a/projects/ngx-web-framework/interceptors/api-error-interceptor.ts
+++ b/projects/ngx-web-framework/interceptors/api-error-interceptor.ts
@@ -1,0 +1,16 @@
+import { HttpEvent, HttpHandlerFn, HttpInterceptorFn, HttpRequest } from "@angular/common/http";
+import { Observable, tap } from "rxjs";
+
+/**
+ * Interceptor responsible for catching and logging global http failures.
+ */
+export const apiErrorInterceptor: HttpInterceptorFn = (
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn
+): Observable<HttpEvent<unknown>> => {
+  return next(req).pipe(
+    tap({
+      error: (err) => console.error(`Error performing request, status code = ${err.status}`),
+    })
+  );
+};

--- a/projects/ngx-web-framework/interceptors/api-interceptor.ts
+++ b/projects/ngx-web-framework/interceptors/api-interceptor.ts
@@ -1,8 +1,14 @@
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { forwardRef, inject, Injectable, Provider } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 import { LanguageService } from '@moryx/ngx-web-framework/services';
 
+// TODO: Remove these interceptors in the next major.
+
+/**
+ * @deprecated Use `languageInterceptor` and `apiErrorInterceptor` functional interceptors instead.
+ * This class will be removed in the next major release.
+ */
 @Injectable()
 export class ApiInterceptor implements HttpInterceptor {
   private languageService = inject(LanguageService);
@@ -25,6 +31,10 @@ export class ApiInterceptor implements HttpInterceptor {
   }
 }
 
+/**
+ * @deprecated Register functional interceptors inside `provideHttpClient(withInterceptors([...]))` instead.
+ * Do not add this provider token to `app.config.ts`.
+ */
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
   useExisting: forwardRef(() => ApiInterceptor),

--- a/projects/ngx-web-framework/interceptors/language-interceptor.ts
+++ b/projects/ngx-web-framework/interceptors/language-interceptor.ts
@@ -1,0 +1,22 @@
+import { HttpEvent, HttpHandlerFn, HttpInterceptorFn, HttpRequest } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { inject } from "@angular/core";
+import { LanguageService } from "@moryx/ngx-web-framework/services";
+
+/**
+ * Interceptor responsible for attaching locale headers to outgoing requests.
+ */
+export const languageInterceptor: HttpInterceptorFn = (
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn
+): Observable<HttpEvent<unknown>> => {
+  const languageService = inject(LanguageService);
+
+  const modifiedReq = req.clone({
+    setHeaders: {
+      'accept-language': `${languageService.getFallbackLang()}-DE`,
+    },
+  });
+
+  return next(modifiedReq);
+};

--- a/projects/ngx-web-framework/interceptors/public-api.ts
+++ b/projects/ngx-web-framework/interceptors/public-api.ts
@@ -1,2 +1,4 @@
 /* Interceptors */
 export * from './api-interceptor';
+export { languageInterceptor } from './language-interceptor';
+export { apiErrorInterceptor } from './api-error-interceptor';


### PR DESCRIPTION
Migrated legacy class-based API interceptor into two, single-responsibility Angular functional Interceptors (`HttpInterceptorFn`). 

Additionally, the old class-based components have been explicitly marked as `@deprecated`.

- Split the `ApiInterceptor` into `languageInterceptor` (adds localization headers) and `apiErrorInterceptor` (handles global error logging).
- emoved the need for `withInterceptorsFromDi()`, explicit class provider injection, and manual multi-provider arrays (`API_INTERCEPTOR_PROVIDER`) in `app.config.ts`.
- Functional interceptors generate less boilerplate code, compile to smaller chunk sizes, and allow for better framework tree-shaking.

Sample:

```typescript
import { languageInterceptor, apiErrorInterceptor } from './api/api.interceptors';

export const appConfig: ApplicationConfig = {
  providers: [
    provideRouter(routes),
    provideHttpClient(
      withInterceptors([languageInterceptor, apiErrorInterceptor])
    ),
  ],
};
```
