### PR TITLE
Fix for some ux issues in entry-editor

### DIFF
--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
@@ -1,19 +1,12 @@
 <div class="entry-checkbox-with-hint entry-editor-item-content">
-  <mat-checkbox
-    (click)="clickContainer($event)"
-    [checked]="checked()"
-    [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-    [name]="name()"
-    color="primary">
-    <div class="checkbox-text-area">
-      {{ name() }}
-      @if (description()) {
-        <mat-hint
-          class="boolean-entry-form-hint"
-          [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }">
-          {{ description() }}
-        </mat-hint>
-      }
-    </div>
+  <mat-checkbox (click)="clickContainer($event)" [checked]="checked()"
+    [disabled]="disabled() || (entry().value.isReadOnly ?? false)" [name]="name()" color="primary">
+    {{ name() }}
   </mat-checkbox>
+  @if (description()) {
+    <mat-hint class="boolean-entry-form-hint"
+      [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }">
+      {{ description() }}
+    </mat-hint>
+  }
 </div>

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.scss
@@ -10,14 +10,6 @@
   line-height: 30px;
 }
 
-.checkbox-text-area {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-  font-size: var(--mat-form-field-filled-label-text-size);
-}
-
 .entry-checkbox-with-hint {
   flex: 1;
   display: flex;
@@ -29,6 +21,6 @@
 
 .boolean-entry-form-hint {
   font-size: 90%;
-  margin-left: -2px;
+  padding-left: 16px;
   color: hsl(0, 0%, 60%);
 }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
@@ -1,26 +1,26 @@
-@if(entryInformation(); as entryInfo) {
+@if (entryInformation(); as entryInfo) {
   @if (entryInfo.entryPath) {
     <div class="navigation-bar">
-      <!-- ToDo: Update tracking as whole collection is recreated every time -->
-      @for (e of entryInfo.entryPath; track e; let isLast = $last) {
-        <span class="navigation-bar-item" (click)="onNavigateSpecific(e)">
-          {{e().displayName}}
-        </span>
-        @if (!isLast) {
-          <span class="material-symbols-outlined navigation-bar-layers navigation-bar-divider">
-            chevron_right
-          </span>
+      <div class="navigation-breadcrumbs">
+        <!-- ToDo: Update tracking as whole collection is recreated every time -->
+        @for (e of entryInfo.entryPath; track e; let isLast = $last) {
+          <mat-chip-set>
+            <mat-chip [highlighted]="isLast" (click)="onNavigateSpecific(e)">{{ e().displayName }}</mat-chip>
+          </mat-chip-set>
+          @if (!isLast) {
+            <mat-icon class="navigation-bar-divider">chevron_right</mat-icon>
+          }
         }
+      </div>
+      @if (entryInfo.currentEntry()?.description; as description) {
+        <p class="navigation-description">{{ description }}</p>
       }
     </div>
   }
 
-  @if (entryInfo.currentEntry()) {
-    <entry-editor
-      [editorId]="editorId()" class="navigation-entries"
-      [entry]="entryInfo.currentEntry()"
-      (entryChange)="onEntryChange($event)"
-      [disabled]="disabled()">
+  @if (entryInfo.currentEntry(); as current) {
+    <entry-editor [editorId]="editorId()" class="navigation-entries" [entry]="current"
+      (entryChange)="onEntryChange($event)" [disabled]="disabled()">
     </entry-editor>
   }
 }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.scss
@@ -4,37 +4,41 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: stretch;
-  padding: 0px 8px;
+  padding: 0 8px;
+
+  --mat-chip-elevated-selected-container-color: var(--mat-sys-surface-container-highest);
+  --mat-chip-selected-label-text-color: var(--mat-sys-on-surface);
+  --mat-chip-container-height: 28px;
 }
 
-.navigation-bar{
-  margin: 0px -8px 8px -8px;
-  padding: 4px 8px;
-  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
-  border-bottom: 1px solid #e5e5e5;
-  overflow-x: auto;
-  overflow-y: hidden;
-  display: flex;
-  align-items: center;
-}
+.navigation {
+  &-bar {
+    margin: 0px -8px 8px -8px;
+    padding: 4px 8px;
+    box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
 
-.navigation-bar-layers{
-  font-size: 14px;
-  line-height: 16px;
-  font-weight: 300;
-}
-.navigation-bar-item {
-  cursor: pointer;
-}
-.navigation-bar-item:hover {
-  text-decoration: underline;
-}
-.navigation-bar-divider {
-  cursor: default;
-}
+    &-divider {
+      color: var(--mat-sys-on-surface-variant);
+    }
+  }
 
-.navigation-entries{
-  flex: 1 1;
-  overflow-x: hidden;
-  overflow-y: auto;
+  &-breadcrumbs {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  &-description {
+    margin: 0 0 4px 0;
+    padding: 0 8px;
+    font-size: 90%;
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  &-entries {
+    flex: 1 1;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
 }

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -1,11 +1,13 @@
 import { Component, OnDestroy, input, model, inject, computed, WritableSignal, untracked, ChangeDetectionStrategy } from '@angular/core';
 import { Entry } from './models/entry';
 import { NavigableEntryService } from './services/navigable-entry.service';
+import { MatChip, MatChipSet } from '@angular/material/chips';
+import { MatIcon } from '@angular/material/icon';
 import { EntryEditor } from './entry-editor';
 
 @Component({
   selector: 'navigable-entry-editor',
-  imports: [EntryEditor],
+  imports: [EntryEditor, MatChipSet, MatChip, MatIcon],
   templateUrl: './navigable-entry-editor.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './navigable-entry-editor.scss',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,9 @@
       "@moryx/ngx-web-framework/interceptors": [
         "./projects/ngx-web-framework/interceptors/index.ts"
       ],
+      "@moryx/ngx-web-framework/material": [
+        "./projects/ngx-web-framework/material/index.ts"
+      ],
       "@moryx/ngx-web-framework": [
         "./projects/ngx-web-framework/src/public-api.ts"
       ]


### PR DESCRIPTION
**Navigable-entry-editor:** 

Reworked navigation to use styled chips and show description of the current entry

<img width="326" height="131" alt="Screenshot 2026-07-15 at 16 20 47" src="https://github.com/user-attachments/assets/fa30a893-42f3-443b-ad73-f3bea5b8fee1" />. 


<img width="425" height="199" alt="Screenshot 2026-07-15 at 16 20 55" src="https://github.com/user-attachments/assets/a39f05c3-2af5-46eb-8a1d-83b04bf834aa" />. 


**Boolean-editor:** 

Moved description under checkbox to keep name centered and in line with checkbox

<img width="310" height="90" alt="Screenshot 2026-07-15 at 15 47 34" src="https://github.com/user-attachments/assets/707d98bb-4385-4ae7-b45d-6b6d3f18c0d6" />
