### PR TITLE
Reworked entry-editor disable behavior and styleguide

### DIFF
--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
@@ -166,7 +166,7 @@ export class EntryEditorDemo {
       {
         // Bool
         displayName: 'Test Disabled Bool Name',
-        description: 'This is a very very very long Disabled Test Bool description.',
+        description: 'This is a very very very very very very very very very long Disabled Test Bool description.',
         identifier: 'Disabled Bool Identifier',
         value: {
           current: undefined,

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
@@ -58,15 +58,15 @@ export class EntryEditorDemo {
       },
       {
         // String
-        displayName: 'Test Disabled String Name',
+        displayName: 'Test Readonly String Name',
         description: 'This is a Test String description.',
-        identifier: 'Disabled String Identifier',
+        identifier: 'Readonly String Identifier',
         validation: {
           isRequired: true,
           regex: '[A-Za-z]+',
         },
         value: {
-          current: 'Current Value of the Disabled Test String',
+          current: 'Current Value of the Readonly Test String',
           default: 'Default Value of the Test String',
           isReadOnly: true,
           possible: undefined,
@@ -165,9 +165,9 @@ export class EntryEditorDemo {
       },
       {
         // Bool
-        displayName: 'Test Disabled Bool Name',
-        description: 'This is a very very very very very very very very very long Disabled Test Bool description.',
-        identifier: 'Disabled Bool Identifier',
+        displayName: 'Test Readonly Bool Name',
+        description: 'This is a very very very very very very very very very long Readonly Test Bool description.',
+        identifier: 'Readonly Bool Identifier',
         value: {
           current: undefined,
           default: undefined,
@@ -285,9 +285,9 @@ export class EntryEditorDemo {
       },
       {
         // Select
-        displayName: 'Test Disabled Select Name',
-        description: 'This is a Disabled Test Select description.',
-        identifier: 'Disabled Select Identifier',
+        displayName: 'Test Readonly Select Name',
+        description: 'This is a Readonly Test Select description.',
+        identifier: 'Readonly Select Identifier',
         value: {
           current: undefined,
           default: undefined,
@@ -303,9 +303,9 @@ export class EntryEditorDemo {
       },
       {
         // Flag Enum
-        displayName: 'Test Disabled Flag Enum Name',
-        description: 'This is a Disabled Test Flag Enum description.',
-        identifier: 'Disabled Flag Enum Identifier',
+        displayName: 'Test Readonly Flag Enum Name',
+        description: 'This is a Readonly Test Flag Enum description.',
+        identifier: 'Readonly Flag Enum Identifier',
         value: {
           current: 'Option1Key, Option3Key',
           default: '',
@@ -335,9 +335,9 @@ export class EntryEditorDemo {
       },
       {
         // File
-        displayName: 'Disabled Test File Name',
-        description: 'This is a Disabled Test File description.',
-        identifier: 'Disabled File Identifier',
+        displayName: 'Readonly Test File Name',
+        description: 'This is a Readonly Test File description.',
+        identifier: 'Readonly File Identifier',
         value: {
           current: undefined,
           default: undefined,

--- a/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
+++ b/projects/moryx-demo/src/app/entry-editor-demo/entry-editor-demo.ts
@@ -14,8 +14,8 @@ import { Entry, EntryUnitType, EntryValueType, NavigableEntryEditor } from '@mor
   imports: [NavigableEntryEditor, MatDivider, MatButtonModule]
 })
 export class EntryEditorDemo {
-  disabled = signal(false);
-  testEntry = signal<Entry>({
+  protected disabled = signal(false);
+  protected testEntry = signal<Entry>({
     displayName: 'Test Entry',
     description: 'This is the description of a test entry',
     identifier: 'RootEntry',
@@ -1104,7 +1104,7 @@ export class EntryEditorDemo {
     "prototypes": []
   });
 
-  acquiredCapabilitiesEntry = signal<Entry>({
+  protected acquiredCapabilitiesEntry = signal<Entry>({
     "displayName": "AcquiredCapabilities",
     "identifier": "AcquiredCapabilities",
     "description": null,
@@ -1282,7 +1282,7 @@ export class EntryEditorDemo {
     ]
   });
 
-  assemblyCellEntry = signal<Entry>({
+  protected assemblyCellEntry = signal<Entry>({
     "displayName": "AssemblyCell",
     "identifier": "AssemblyCell",
     "description": null,
@@ -1495,15 +1495,15 @@ export class EntryEditorDemo {
     "prototypes": []
   });
 
-  onToggle() {
+  protected onToggle() {
     this.disabled.update(current => !current);
   }
 
-  replaceEntry() {
+  protected replaceEntry() {
     this.testEntry.set(this.assemblyCellEntry());
   }
 
-  onEntryChange($event: Entry) {
+  protected onEntryChange($event: Entry) {
     console.log('Entry changed:', $event);
     this.testEntry.set($event);
   }

--- a/projects/moryx-demo/src/app/snackbar-demo/snackbar-demo.ts
+++ b/projects/moryx-demo/src/app/snackbar-demo/snackbar-demo.ts
@@ -17,15 +17,15 @@ export class SnackbarDemo {
   constructor(private snackbarService: SnackbarService) {
   }
 
-  handlePermissionsMissing(): void {
+  protected handlePermissionsMissing(): void {
     this.snackbarService.handleError(new HttpErrorResponse({error: this.multiplePermissions, status: 403}));
   }
 
-  handlePermissionMissing(): void {
+  protected handlePermissionMissing(): void {
     this.snackbarService.handleError(new HttpErrorResponse({error: this.singlePermission, status: 403}));
   }
 
-  handleForbidden(): void {
+  protected handleForbidden(): void {
     this.snackbarService.handleError(new HttpErrorResponse({status: 403}));
   }
 }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
@@ -10,8 +10,8 @@
     }
   </div>
   @if (description()) {
-    <mat-hint class="truncate" [class.entry-editor-disabled]="disabled()">
+    <div class="entry-hint truncate" [class.entry-editor-disabled]="disabled()">
       {{ description() }}
-    </mat-hint>
+    </div>
   }
 </div>

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
@@ -10,7 +10,7 @@
     }
   </div>
   @if (description()) {
-    <mat-hint class="truncate" [ngClass]="{ 'entry-editor-disabled': disabled() }">
+    <mat-hint class="truncate" [class.entry-editor-disabled]="disabled()">
       {{ description() }}
     </mat-hint>
   }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.html
@@ -1,11 +1,16 @@
-<div class="entry-checkbox-with-hint entry-editor-item-content">
-  <mat-checkbox (click)="clickContainer($event)" [checked]="checked()"
-    [disabled]="disabled() || (entry().value.isReadOnly ?? false)" [name]="name()" color="primary">
-    {{ name() }}
-  </mat-checkbox>
+<div class="boolean-editor">
+  <div class="boolean-input-row">
+    <mat-checkbox (click)="clickContainer($event)" [checked]="checked()"
+      [disabled]="disabled() || (entry().value.isReadOnly ?? false)" [name]="name()" color="primary"
+      [class.readonly]="(entry().value.isReadOnly ?? false) && !disabled()">
+      {{ name() }}
+    </mat-checkbox>
+    @if (entry().value.isReadOnly) {
+      <mat-icon [class.entry-editor-disabled]="disabled()">lock</mat-icon>
+    }
+  </div>
   @if (description()) {
-    <mat-hint class="boolean-entry-form-hint"
-      [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }">
+    <mat-hint class="truncate" [ngClass]="{ 'entry-editor-disabled': disabled() }">
       {{ description() }}
     </mat-hint>
   }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.scss
@@ -1,26 +1,33 @@
 @use "../style/entry-editor-base" as *;
 
-.mat-checkbox .mat-checkbox-inner-container {
-  transform: scale(1.3);
-  margin-right: 10px;
-}
-
-.mat-checkbox {
-  margin-left: 2px;
-  line-height: 30px;
-}
-
-.entry-checkbox-with-hint {
+.boolean-editor {
   flex: 1;
   display: flex;
-  flex-flow: column nowrap;
-  align-items: stretch;
-  justify-content: center;
+  flex-direction: column;
   padding-bottom: 0.875em;
 }
 
-.boolean-entry-form-hint {
-  font-size: 90%;
+.boolean-input-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  mat-icon {
+    margin-right: 8px;
+  }
+}
+
+.readonly {
+  --mat-checkbox-disabled-label-color: var(--mat-sys-on-surface);
+}
+
+mat-hint {
+  display: block;
+  font: var(--mat-sys-body-small);
   padding-left: 16px;
-  color: hsl(0, 0%, 60%);
+  color: var(--mat-sys-on-surface-variant);
+
+  &.entry-editor-disabled {
+    color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
+  }
 }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.scss
@@ -21,13 +21,3 @@
   --mat-checkbox-disabled-label-color: var(--mat-sys-on-surface);
 }
 
-mat-hint {
-  display: block;
-  font: var(--mat-sys-body-small);
-  padding-left: 16px;
-  color: var(--mat-sys-on-surface-variant);
-
-  &.entry-editor-disabled {
-    color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
-  }
-}

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -3,7 +3,6 @@ import { Entry } from '../models/entry';
 import { MatHint } from '@angular/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
-import { CommonModule, NgClass } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 
 @Component({
@@ -11,7 +10,7 @@ import { MatIcon } from '@angular/material/icon';
   templateUrl: './boolean-editor.html',
   styleUrls: ['./boolean-editor.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, MatHint, MatCheckbox, FormsModule, NgClass, MatIcon],
+  imports: [MatHint, MatCheckbox, FormsModule, MatIcon],
 })
 export class BooleanEditor {
   checked = signal<boolean>(false);

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -13,12 +13,12 @@ import { MatIcon } from '@angular/material/icon';
   imports: [MatHint, MatCheckbox, FormsModule, MatIcon],
 })
 export class BooleanEditor {
-  checked = signal<boolean>(false);
-  name = signal<string>('');
-  description = signal<string>('');
-
   disabled = input<boolean>(false);
   entry = model.required<Entry>();
+
+  protected checked = signal<boolean>(false);
+  protected name = signal<string>('');
+  protected description = signal<string>('');
 
   constructor() {
     // Todo: Replace effect with computed
@@ -37,7 +37,7 @@ export class BooleanEditor {
     this.name.set(this.entry().displayName ?? '');
   }
 
-  checkedUpdated(value: boolean) {
+  private checkedUpdated(value: boolean) {
     this.checked.update(e => !e);
     this.entry.update(e => {
       let copy = Object.assign({}, e);
@@ -46,7 +46,7 @@ export class BooleanEditor {
     });
   }
 
-  clickContainer(event: MouseEvent) {
+  protected clickContainer(event: MouseEvent) {
     if (!this.disabled() && !(this.entry().value.isReadOnly ?? false)) {
       this.checkedUpdated(!this.checked());
     }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -1,17 +1,17 @@
-import { Component, effect, input, model, signal, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, effect, input, model, signal, ChangeDetectionStrategy } from '@angular/core';
 import { Entry } from '../models/entry';
 import { MatHint } from '@angular/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
 import { CommonModule, NgClass } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
   selector: 'entry-boolean-editor',
   templateUrl: './boolean-editor.html',
   styleUrls: ['./boolean-editor.scss'],
-  encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, MatHint, MatCheckbox, FormsModule, NgClass],
+  imports: [CommonModule, MatHint, MatCheckbox, FormsModule, NgClass, MatIcon],
 })
 export class BooleanEditor {
   checked = signal<boolean>(false);
@@ -48,7 +48,7 @@ export class BooleanEditor {
   }
 
   clickContainer(event: MouseEvent) {
-    if (!this.disabled()) {
+    if (!this.disabled() && !(this.entry().value.isReadOnly ?? false)) {
       this.checkedUpdated(!this.checked());
     }
   }

--- a/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/boolean-editor/boolean-editor.ts
@@ -1,6 +1,5 @@
 import { Component, effect, input, model, signal, ChangeDetectionStrategy } from '@angular/core';
 import { Entry } from '../models/entry';
-import { MatHint } from '@angular/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
@@ -10,7 +9,7 @@ import { MatIcon } from '@angular/material/icon';
   templateUrl: './boolean-editor.html',
   styleUrls: ['./boolean-editor.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [MatHint, MatCheckbox, FormsModule, MatIcon],
+  imports: [MatCheckbox, FormsModule, MatIcon],
 })
 export class BooleanEditor {
   disabled = input<boolean>(false);

--- a/projects/ngx-web-framework/entry-editor/entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.html
@@ -11,7 +11,7 @@
     </mat-form-field>
 
     <button mat-icon-button class="entry-editor-add-list-item-button" type="button"
-      (click)="addItemToList()" [disabled]="disabled()" [ngClass]="{ disabled: disabled() }">
+      (click)="addItemToList()" [disabled]="disabled()" [class.disabled]="disabled()">
       <mat-icon>playlist_add</mat-icon>
     </button>
   </div>
@@ -32,7 +32,7 @@
         <mat-icon matSuffix [class.entry-editor-disabled]="disabled()">lock</mat-icon>
       }
       @if (entry().description) {
-        <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
+        <mat-hint [class.entry-editor-disabled]="disabled()" class="truncate">
           {{ entry().description }}
         </mat-hint>
       }

--- a/projects/ngx-web-framework/entry-editor/entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.html
@@ -5,21 +5,14 @@
       <!-- Check for missing readonly integration for disabled fields and create combined/computed field -->
       <mat-select [(ngModel)]="selectedListItemType" [disabled]="disabled()">
         @for (pv of possibleListItemTypes(); track pv.key) {
-          <mat-option [value]="pv.key">
-            {{ pv.displayName ?? pv.key }}
-          </mat-option>
+          <mat-option [value]="pv.key">{{ pv.displayName ?? pv.key }}</mat-option>
         }
       </mat-select>
     </mat-form-field>
 
-    <button
-      mat-icon-button
-      class="entry-editor-add-list-item-button"
-      type="button"
-      (click)="addItemToList()"
-      [disabled]="disabled()"
-      [ngClass]="{ disabled: disabled() }">
-      <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_add</span>
+    <button mat-icon-button class="entry-editor-add-list-item-button" type="button"
+      (click)="addItemToList()" [disabled]="disabled()" [ngClass]="{ disabled: disabled() }">
+      <mat-icon>playlist_add</mat-icon>
     </button>
   </div>
 }
@@ -29,21 +22,17 @@
   <div class="settable-dropdown-entry">
     <mat-form-field appearance="outline" class="settable-dropdown-entry-selector" subscriptSizing="dynamic">
       <mat-label>{{ entry().displayName }}</mat-label>
-
-      <mat-select
-        [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-        [(ngModel)]="entry().value.current"
-        (selectionChange)="dropdownSelectionChanged($event)">
+      <mat-select [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
+        [(ngModel)]="entry().value.current" (selectionChange)="dropdownSelectionChanged($event)">
         @for (pv of entry().value.possible; track pv.key) {
-          <mat-option [value]="pv.key">
-            {{ pv.displayName ?? pv.key }}
-          </mat-option>
+          <mat-option [value]="pv.key">{{ pv.displayName ?? pv.key }}</mat-option>
         }
       </mat-select>
+      @if (entry().value.isReadOnly) {
+        <mat-icon matSuffix [class.entry-editor-disabled]="disabled()">lock</mat-icon>
+      }
       @if (entry().description) {
-        <mat-hint
-          [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
-          class="truncate">
+        <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
           {{ entry().description }}
         </mat-hint>
       }
@@ -58,61 +47,36 @@
       @if (EntryValueType.Collection === entry().value.type) {
         <!-- ToDo: Add error message to indicate missing editor id in using application -->
         @if (editorId()) {
-          <entry-list-item
-            matLine
-            class="entry-editor-subentries-list-item"
-            [editorId]="editorId()!"
-            [entry]="subEntry"
-            (entryChange)="updateSubEntry($event)"
-            [disabled]="disabled()"
+          <entry-list-item matLine class="entry-editor-subentries-list-item" [editorId]="editorId()!"
+            [entry]="subEntry" (entryChange)="updateSubEntry($event)" [disabled]="disabled()"
             (deleteRequest)="onDeleteListItem($event)">
           </entry-list-item>
         }
       } @else if (EntryValueType.Stream === subEntry.value.type) {
-        <entry-file-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
+        <entry-file-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)" [disabled]="disabled()">
         </entry-file-editor>
       } @else if (EntryValueType.Class === subEntry.value.type || EntryValueType.Collection === subEntry.value.type) {
         <!-- ToDo: Add error message to indicate missing editor id in using application -->
         @if (editorId()) {
-          <entry-object-editor
-            matLine
-            class="entry-editor-subentries-list-item"
-            [entry]="subEntry"
-            [editorId]="editorId()!"
-            [disabled]="disabled()">
+          <entry-object-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
+            [editorId]="editorId()!" [disabled]="disabled()">
           </entry-object-editor>
         }
       } @else if (EntryValueType.Boolean === subEntry.value.type) {
-        <entry-boolean-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
+        <entry-boolean-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)" [disabled]="disabled()">
         </entry-boolean-editor>
         <!-- ToDo remove isEntryTypeSettable call, which is for class drop downs which are handled elsewhere -->
       } @else if (EntryValueType.Enum === subEntry.value.type ||
                   ((subEntry.value.possible?.length ?? 0) > 1 &&
                    !isEntryTypeSettable(subEntry))) {
-        <entry-enum-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
+        <entry-enum-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)" [disabled]="disabled()">
         </entry-enum-editor>
       } @else if (isPrimitiveType(subEntry)) {
-        <entry-input-editor
-          matLine
-          class="entry-editor-subentries-list-item"
-          [entry]="subEntry"
-          (entryChange)="updateSubEntry($event)"
-          [disabled]="disabled()">
+        <entry-input-editor matLine class="entry-editor-subentries-list-item" [entry]="subEntry"
+          (entryChange)="updateSubEntry($event)" [disabled]="disabled()">
         </entry-input-editor>
       }
     }

--- a/projects/ngx-web-framework/entry-editor/entry-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.scss
@@ -34,3 +34,25 @@
 .settable-dropdown-entry-selector{
   width: 100%;
 }
+
+.entry-editor-add-list-item {
+  display: flex;
+  align-items: center;
+  margin: 0px 0px 1px 0px;
+  height: fit-content;
+  padding-top: 5px;
+}
+
+.entry-editor-add-list-item-type-selector {
+  flex: 1 1;
+  margin-right: 8px;
+}
+
+.entry-editor-add-list-item-button {
+  height: 38px;
+  width: 38px;
+  margin: 2px 4px 4px -2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -8,7 +8,7 @@ import { BooleanEditor } from './boolean-editor/boolean-editor';
 import { MatLineModule, MatOption } from '@angular/material/core';
 import { CommonModule, NgClass } from '@angular/common';
 import { MatList } from '@angular/material/list';
-import { MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatHint, MatSuffix } from '@angular/material/form-field';
 import { MatSelect, MatSelectChange } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
 import { EnumEditor } from './enum-editor/enum-editor';
@@ -17,6 +17,7 @@ import { FileEditor } from './file-editor/file-editor';
 import { EntryObject } from './entry-object/entry-object';
 import { EntryListItem } from './entry-list-item/entry-list-item';
 import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
   selector: 'entry-editor',
@@ -37,7 +38,9 @@ import { MatIconButton } from '@angular/material/button';
     CommonModule,
     FormsModule,
     MatIconButton,
-    MatHint
+    MatIcon,
+    MatHint,
+    MatSuffix
   ],
   templateUrl: './entry-editor.html',
   changeDetection: ChangeDetectionStrategy.Eager,

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -6,7 +6,6 @@ import { EntryValueType } from './models/entry-value-type';
 import { PrototypeToEntryConverter } from './prototype-to-entry-converter';
 import { BooleanEditor } from './boolean-editor/boolean-editor';
 import { MatLineModule, MatOption } from '@angular/material/core';
-import { CommonModule, NgClass } from '@angular/common';
 import { MatList } from '@angular/material/list';
 import { MatFormField, MatLabel, MatHint, MatSuffix } from '@angular/material/form-field';
 import { MatSelect, MatSelectChange } from '@angular/material/select';
@@ -29,13 +28,11 @@ import { MatIcon } from '@angular/material/icon';
     EntryObject,
     EntryListItem,
     MatLineModule,
-    NgClass,
     MatList,
     MatFormField,
     MatLabel,
     MatSelect,
     MatOption,
-    CommonModule,
     FormsModule,
     MatIconButton,
     MatIcon,

--- a/projects/ngx-web-framework/entry-editor/entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.ts
@@ -44,17 +44,21 @@ import { MatIcon } from '@angular/material/icon';
   styleUrl: './entry-editor.scss',
 })
 export class EntryEditor {
+  /** Unique identifier to support multiple navigable entry editors simultaneously. */
   editorId = input<number | undefined>(undefined);
+
+  /** Whether the editor is disabled. */
   disabled = input<boolean>(false);
 
+  /** The entry to display and edit. Changes are propagated back via two-way binding. */
   entry = model.required<Entry>();
-  currentEntry: Entry | undefined = undefined;
-  subEntries = signal<Entry[]>([]);
 
-  possibleListItemTypes = signal<EntryPossible[] | undefined | null>(undefined);
-  prototypes = signal<Entry[]>([]);
-  selectedListItemType = signal<string | undefined>(undefined);
-  selectedEntryHasPrototypes = signal(true);
+  private currentEntry: Entry | undefined = undefined;
+
+  protected possibleListItemTypes = signal<EntryPossible[] | undefined | null>(undefined);
+  private prototypes = signal<Entry[]>([]);
+  protected selectedListItemType = signal<string | undefined>(undefined);
+  private selectedEntryHasPrototypes = signal(true);
 
   private createdCounter?: number;
 
@@ -83,7 +87,7 @@ export class EntryEditor {
   // - creating a new entry object with the updated value and replacing the old in the mapping
   // - propagating this reference change upwards in the array
   // ToDo: In future a 'ReactiveEntry' wrapper would improve performance and reduce reference copying effort
-  updateSubEntry(subEntry: Entry) {
+  protected updateSubEntry(subEntry: Entry) {
     this.entry.update(item => {
       const match = item.subEntries?.find(x => x.identifier === subEntry.identifier);
       if (!match)
@@ -99,10 +103,10 @@ export class EntryEditor {
   }
 
   // ToDo: Move to correct place
-  EntryValueType = EntryValueType;
-  EntryUnitType = EntryUnitType;
+  protected EntryValueType = EntryValueType;
+  protected EntryUnitType = EntryUnitType;
 
-  onDeleteListItem(toBeDeleted: Entry) {
+  protected onDeleteListItem(toBeDeleted: Entry) {
     const entry = this.entry();
 
     if (entry.subEntries) {
@@ -114,7 +118,7 @@ export class EntryEditor {
     }
   }
 
-  addItemToList() {
+  protected addItemToList() {
     const prototypes = this.prototypes();
 
     // ToDo: Clean up function
@@ -149,13 +153,13 @@ export class EntryEditor {
     }
   }
 
-  isEntryTypeSettable(entry: Entry): boolean {
+  protected isEntryTypeSettable(entry: Entry): boolean {
     return  entry?.value?.type === EntryValueType.Class &&
       entry.value.possible != null &&
       entry.value.possible.length > 1;
   }
 
-  onPatchToSelectedEntryType(keyPair: EntryPossible): void {
+  private onPatchToSelectedEntryType(keyPair: EntryPossible): void {
     this.entry.update(entry => {
       entry.subEntries = [];
       const prototype = entry?.prototypes?.find((proto: Entry) => proto.identifier === keyPair.key);
@@ -175,11 +179,11 @@ export class EntryEditor {
   }
 
   // ToDo: Remove unnecessary wrapper function
-  dropdownSelectionChanged(event: MatSelectChange){
+  protected dropdownSelectionChanged(event: MatSelectChange){
     this.onPatchToSelectedEntryType(event.value);
   }
 
-  isPrimitiveType(entry: Entry){
+  protected isPrimitiveType(entry: Entry){
     return entry.value.type !== EntryValueType.Collection &&
       (entry.value.possible && entry.value.possible.length === 1) ||
       (((entry.value.possible && entry.value.possible.length < 1) || !entry.value.possible)  &&

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
@@ -30,7 +30,7 @@
     }
 
     <button mat-icon-button class="entry-list-item-delete" type="button" (click)="onDelete()"
-      [disabled]="disabled()" [ngClass]="{ disabled: disabled() }">
+      [disabled]="disabled()" [class.disabled]="disabled()">
       <mat-icon>playlist_remove</mat-icon>
     </button>
   </div>

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.html
@@ -2,33 +2,17 @@
   <div class="entry-list-item-content">
     <!-- ToDo: Use switch case & Check for missing signal updates -->
     @if (EntryValueType.Stream === entry().value.type) {
-      <entry-file-editor
-        matLine
-        class="entry-list-item-value"
-        [entry]="entry()"
-        (entryChange)="entry.set($event)"
-        [disabled]="disabled()" />
+      <entry-file-editor matLine class="entry-list-item-value" [entry]="entry()"
+        (entryChange)="entry.set($event)" [disabled]="disabled()" />
     } @else if (EntryValueType.Class === entry().value.type || EntryValueType.Collection === entry().value.type) {
-      <entry-object-editor
-        matLine
-        class="entry-list-item-value"
-        [entry]="entry()"
-        [editorId]="editorId()"
-        [disabled]="disabled()" />
+      <entry-object-editor matLine class="entry-list-item-value" [entry]="entry()"
+        [editorId]="editorId()" [disabled]="disabled()" />
     } @else if (EntryValueType.Boolean === entry().value.type) {
-      <entry-boolean-editor
-        matLine
-        class="entry-list-item-value"
-        [entry]="entry()"
-        (entryChange)="entry.set($event)"
-        [disabled]="disabled()" />
+      <entry-boolean-editor matLine class="entry-list-item-value" [entry]="entry()"
+        (entryChange)="entry.set($event)" [disabled]="disabled()" />
     } @else if (EntryValueType.Enum === entry().value.type) {
-      <entry-enum-editor
-        matLine
-        class="entry-list-item-value"
-        [entry]="entry()"
-        (entryChange)="entry.set($event)"
-        [disabled]="disabled()" />
+      <entry-enum-editor matLine class="entry-list-item-value" [entry]="entry()"
+        (entryChange)="entry.set($event)" [disabled]="disabled()" />
     } @else if (EntryValueType.Byte === entry().value.type ||
                 EntryValueType.Int16 === entry().value.type ||
                 EntryValueType.UInt16 === entry().value.type ||
@@ -40,23 +24,14 @@
                 EntryValueType.Double === entry().value.type ||
                 EntryValueType.String === entry().value.type ||
                 EntryValueType.Exception === entry().value.type) {
-                  <!-- ToDo: Check reuse of isprimitive type function for condition -->
-      <entry-input-editor
-        matLine
-        class="entry-list-item-value"
-        [entry]="entry()"
-        (entryChange)="entry.set($event)"
-        [disabled]="disabled()" />
+      <!-- ToDo: Check reuse of isprimitive type function for condition -->
+      <entry-input-editor matLine class="entry-list-item-value" [entry]="entry()"
+        (entryChange)="entry.set($event)" [disabled]="disabled()" />
     }
 
-    <button
-      mat-icon-button
-      class="entry-list-item-delete"
-      type="button"
-      (click)="onDelete()"
-      [disabled]="disabled()"
-      [ngClass]="{ disabled: disabled() }">
-      <span class="material-symbols-outlined entry-editor-list-item-button-icon">playlist_remove</span>
+    <button mat-icon-button class="entry-list-item-delete" type="button" (click)="onDelete()"
+      [disabled]="disabled()" [ngClass]="{ disabled: disabled() }">
+      <mat-icon>playlist_remove</mat-icon>
     </button>
   </div>
 </div>

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, input, model, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, model, output, ChangeDetectionStrategy } from '@angular/core';
 import { Entry } from '../models/entry';
 import { EntryValueType } from '../models/entry-value-type';
 import { FileEditor } from '../file-editor/file-editor';
@@ -32,11 +32,11 @@ export class EntryListItem {
   entry = model.required<Entry>();
   editorId = input.required<number>();
   disabled = input<boolean>(false);
-  @Output() deleteRequest: EventEmitter<Entry> = new EventEmitter<Entry>();
+  deleteRequest = output<Entry>();
 
-  EntryValueType = EntryValueType;
+  protected EntryValueType = EntryValueType;
 
-  onDelete() {
+  protected onDelete() {
     this.deleteRequest.emit(this.entry());
   }
 }

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
@@ -10,6 +10,7 @@ import { EnumEditor } from '../enum-editor/enum-editor';
 import { CommonModule } from '@angular/common';
 import { MatLine } from '@angular/material/core';
 import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 
 @Component({
@@ -23,6 +24,7 @@ import { MatListModule } from '@angular/material/list';
     CommonModule,
     MatLine,
     MatIconButton,
+    MatIcon,
     MatListModule,
   ],
   templateUrl: './entry-list-item.html',

--- a/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-list-item/entry-list-item.ts
@@ -6,8 +6,6 @@ import { EntryObject} from '../entry-object/entry-object';
 import { BooleanEditor } from '../boolean-editor/boolean-editor';
 import { InputEditor } from '../input-editor/input-editor';
 import { EnumEditor } from '../enum-editor/enum-editor';
-// ToDo: Remove common module import
-import { CommonModule } from '@angular/common';
 import { MatLine } from '@angular/material/core';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -21,7 +19,6 @@ import { MatListModule } from '@angular/material/list';
     BooleanEditor,
     InputEditor,
     EnumEditor,
-    CommonModule,
     MatLine,
     MatIconButton,
     MatIcon,

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
@@ -5,7 +5,7 @@
   </button>
 
   @if (entry().description) {
-    <div class="object-entry-hint" [class.entry-editor-disabled]="disabled()">
+    <div class="entry-hint" [class.entry-editor-disabled]="disabled()">
       {{ entry().description }}
     </div>
   }

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.html
@@ -1,11 +1,11 @@
-<div class="entry-object-wrapper">
+<div class="entry-object">
   <button mat-stroked-button (click)="onOpen()" type="button">
     {{ entry().displayName }}
     <mat-icon iconPositionEnd>chevron_right</mat-icon>
   </button>
 
   @if (entry().description) {
-    <div class="object-entry-hint" [class.entry-editor-disabled]="disabled() || (entry().value.isReadOnly ?? false)">
+    <div class="object-entry-hint" [class.entry-editor-disabled]="disabled()">
       {{ entry().description }}
     </div>
   }

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.scss
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.scss
@@ -1,18 +1,18 @@
 @use "../style/entry-editor-base";
 
-.entry-object-wrapper {
+.entry-object {
   display: flex;
   flex-direction: column;
   width: 100%;
 }
 
 .object-entry-hint {
-  font-size: 12px;
-  line-height: 16px;
+  font: var(--mat-sys-body-small);
   margin-top: 4px;
   padding-left: 16px;
-}
+  color: var(--mat-sys-on-surface-variant);
 
-.entry-editor-disabled {
-  opacity: 0.6;
+  &.entry-editor-disabled {
+    color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
+  }
 }

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.scss
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.scss
@@ -6,13 +6,3 @@
   width: 100%;
 }
 
-.object-entry-hint {
-  font: var(--mat-sys-body-small);
-  margin-top: 4px;
-  padding-left: 16px;
-  color: var(--mat-sys-on-surface-variant);
-
-  &.entry-editor-disabled {
-    color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
-  }
-}

--- a/projects/ngx-web-framework/entry-editor/entry-object/entry-object.ts
+++ b/projects/ngx-web-framework/entry-editor/entry-object/entry-object.ts
@@ -18,7 +18,7 @@ export class EntryObject {
   editorId = input.required<number>();
   disabled = input<boolean>(false);
 
-  onOpen(){
+  protected onOpen(){
     this.navigableEntryService.onOpenEntry(this.editorId(), this.entry());
   }
 }

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
@@ -1,17 +1,19 @@
 <mat-form-field class="full-width-input entry-form-field" appearance="outline" subscriptSizing="dynamic">
-  <mat-label>{{entry().displayName}}</mat-label>
-  <mat-select [formControl]="formControl" (selectionChange)="changed($event)"
-              [multiple]="isFlagEnum()">
+  <mat-label>{{ entry().displayName }}</mat-label>
+  <mat-select [formControl]="formControl" (selectionChange)="changed($event)" [multiple]="isFlagEnum()">
     @for (pv of entry().value.possible; track pv) {
-      <mat-option [value]="pv.key">
+      <mat-option [value]="pv.key" [disabled]="entry().value.isReadOnly ?? false">
         {{ pv.displayName ?? pv.key }}
       </mat-option>
     }
   </mat-select>
+  @if (entry().value.isReadOnly) {
+    <mat-icon matSuffix [class.entry-editor-disabled]="disabled()">lock</mat-icon>
+  }
   @if (entry().description) {
     <!-- ToDo: Check truncate class not working -->
-    <mat-hint [ngClass]="{'entry-editor-disabled': (disabled() || (entry().value.isReadOnly ?? false))}" class="truncate">
-      {{entry().description}}
+    <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
+      {{ entry().description }}
     </mat-hint>
   }
 </mat-form-field>

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.html
@@ -12,7 +12,7 @@
   }
   @if (entry().description) {
     <!-- ToDo: Check truncate class not working -->
-    <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
+    <mat-hint [class.entry-editor-disabled]="disabled()" class="truncate">
       {{ entry().description }}
     </mat-hint>
   }

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
@@ -1,6 +1,5 @@
 import { Component, effect, input, model, untracked, ChangeDetectionStrategy } from '@angular/core';
 import { Entry } from '../models/entry';
-import { NgClass } from '@angular/common';
 import { MatFormField, MatHint, MatLabel, MatSuffix } from '@angular/material/form-field';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
@@ -9,7 +8,7 @@ import { EntryUnitType } from '../models/entry-unit-type';
 
 @Component({
   selector: 'entry-enum-editor',
-  imports: [NgClass, MatFormField, MatLabel, MatSuffix, MatSelect, MatOption, FormsModule, ReactiveFormsModule, MatIcon, MatHint],
+  imports: [MatFormField, MatLabel, MatSuffix, MatSelect, MatOption, FormsModule, ReactiveFormsModule, MatIcon, MatHint],
   templateUrl: './enum-editor.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './enum-editor.scss',

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
@@ -44,7 +44,10 @@ export class EnumEditor {
       return copy;
     });
 
-    if (disabled) this.formControl.disable();
+    if (disabled) {
+      this.formControl.disable();
+    }
+
     else this.formControl.enable();
   }
 

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
@@ -16,7 +16,8 @@ import { EntryUnitType } from '../models/entry-unit-type';
 export class EnumEditor {
   disabled = input<boolean>(false);
   entry = model.required<Entry>();
-  formControl = new UntypedFormControl('');
+
+  protected formControl = new UntypedFormControl('');
 
   constructor() {
     effect(() => {
@@ -47,7 +48,7 @@ export class EnumEditor {
     else this.formControl.enable();
   }
 
-  changed(event: any) {
+  protected changed(event: any) {
     if (this.entry().value.isReadOnly) return;
     if (Array.isArray(this.formControl.value) && this.formControl.value.length > 0) {
       this.entry.update(e => {
@@ -68,7 +69,7 @@ export class EnumEditor {
     }
   }
 
-  isFlagEnum(): boolean {
+  protected isFlagEnum(): boolean {
     return this.entry().value.unitType === EntryUnitType.Flags
   }
 }

--- a/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/enum-editor/enum-editor.ts
@@ -1,14 +1,15 @@
 import { Component, effect, input, model, untracked, ChangeDetectionStrategy } from '@angular/core';
 import { Entry } from '../models/entry';
-import { CommonModule } from '@angular/common';
-import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { NgClass } from '@angular/common';
+import { MatFormField, MatHint, MatLabel, MatSuffix } from '@angular/material/form-field';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { MatIcon } from '@angular/material/icon';
 import { EntryUnitType } from '../models/entry-unit-type';
 
 @Component({
   selector: 'entry-enum-editor',
-  imports: [CommonModule, MatFormField, MatLabel, MatSelect, MatOption, FormsModule, ReactiveFormsModule],
+  imports: [NgClass, MatFormField, MatLabel, MatSuffix, MatSelect, MatOption, FormsModule, ReactiveFormsModule, MatIcon, MatHint],
   templateUrl: './enum-editor.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './enum-editor.scss',
@@ -43,11 +44,12 @@ export class EnumEditor {
       return copy;
     });
 
-    if (disabled || (entry.value.isReadOnly ?? false)) this.formControl.disable();
+    if (disabled) this.formControl.disable();
     else this.formControl.enable();
   }
 
   changed(event: any) {
+    if (this.entry().value.isReadOnly) return;
     if (Array.isArray(this.formControl.value) && this.formControl.value.length > 0) {
       this.entry.update(e => {
         e.value.current = this.formControl.value.join(",");

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.html
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.html
@@ -3,31 +3,21 @@
   <div class="moryx-file-input file-upload">
     <mat-form-field appearance="outline" class="file-input-field entry-form-field" subscriptSizing="dynamic">
       <mat-label>{{ entry().displayName }}</mat-label>
-      <input
-        matInput
-        [formControl]="inputFormControl"
-        aria-label="Text field for selecting a file path."
-        title="Filename"
-        class="file-input-field"
-        [placeholder]="
-          inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-            ? entry().value.default ?? ''
-            : ''
-        " />
-      <button
-        mat-icon-button
-        (click)="fileUpload.click()"
-        class="file-input-button"
-        type="button"
-        [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
-        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
-        matSuffix>
-        <span class="material-symbols-outlined">upload</span>
-      </button>
+      <input matInput [formControl]="inputFormControl" [readonly]="entry().value.isReadOnly ?? false"
+        aria-label="Text field for selecting a file path." title="Filename" class="file-input-field"
+        [placeholder]="inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+          ? entry().value.default ?? ''
+          : ''" />
+      @if (entry().value.isReadOnly) {
+        <mat-icon matSuffix [class.entry-editor-disabled]="disabled()">lock</mat-icon>
+      } @else {
+        <button mat-icon-button (click)="fileUpload.click()" class="file-input-button" type="button"
+          [disabled]="disabled()" matPrefix>
+          <mat-icon>upload</mat-icon>
+        </button>
+      }
       @if (entry().description) {
-        <mat-hint
-          [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
-          class="truncate">
+        <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
           {{ entry().description }}
         </mat-hint>
       }

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.html
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.html
@@ -17,7 +17,7 @@
         </button>
       }
       @if (entry().description) {
-        <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
+        <mat-hint [class.entry-editor-disabled]="disabled()" class="truncate">
           {{ entry().description }}
         </mat-hint>
       }

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.scss
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.scss
@@ -1,3 +1,5 @@
+@use "../style/entry-editor-base" as *;
+
 .file-editor-container {
   flex: 1 1 auto;
   display: flex;

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
@@ -4,21 +4,20 @@ import { Entry } from '../models/entry';
 import { EntryValueType } from '../models/entry-value-type';
 import { EntryValue } from '../models/entry-value';
 import { CommonModule } from '@angular/common';
-import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatError, MatFormField, MatLabel, MatPrefix } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconButton } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'entry-file-editor',
-  imports: [CommonModule, MatFormField, MatLabel, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule],
+  imports: [CommonModule, MatFormField, MatLabel, MatPrefix, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule],
   templateUrl: './file-editor.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './file-editor.scss',
 })
 export class FileEditor {
   inputFormControl!: UntypedFormControl;
-  private readOnly: boolean | undefined = undefined;
 
   disabled = input<boolean>(false);
   entry = model.required<Entry>();
@@ -37,7 +36,6 @@ export class FileEditor {
   private initialize(entry: Entry) {
     const validators = this.setupValidators(entry);
     this.inputFormControl = this.setupFormControl(entry, validators);
-    this.readOnly = entry.value?.isReadOnly;
   }
 
   private updateCurrentValue(currentValue: EntryValue, value: any) {
@@ -49,7 +47,7 @@ export class FileEditor {
   }
 
   disableInputFormControl(control: UntypedFormControl, disable: boolean) {
-    if (disable || this.readOnly)
+    if (disable)
       control.disable();
     else
       control.enable();
@@ -69,7 +67,7 @@ export class FileEditor {
     const ctrl = new UntypedFormControl(
       {
         value: initial,
-        disabled: this.disabled() || (entry.value.isReadOnly ?? false) || entry.value?.type === EntryValueType.Stream,
+        disabled: this.disabled() || entry.value?.type === EntryValueType.Stream,
       },
       validators
     );

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
@@ -16,7 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
   styleUrl: './file-editor.scss',
 })
 export class FileEditor {
-  inputFormControl!: UntypedFormControl;
+  protected inputFormControl!: UntypedFormControl;
 
   disabled = input<boolean>(false);
   entry = model.required<Entry>();
@@ -45,14 +45,14 @@ export class FileEditor {
     });
   }
 
-  disableInputFormControl(control: UntypedFormControl, disable: boolean) {
+  private disableInputFormControl(control: UntypedFormControl, disable: boolean) {
     if (disable)
       control.disable();
     else
       control.enable();
   }
 
-  setupValidators(entry: Entry): ValidatorFn[] {
+  private setupValidators(entry: Entry): ValidatorFn[] {
     let validators = [] as ValidatorFn[];
     if (entry.validation?.isRequired)
       validators.push(Validators.required);
@@ -75,7 +75,7 @@ export class FileEditor {
   }
 
 
-  onFileSelected(event: any){
+  protected onFileSelected(event: any){
     const file:File = event.target.files[0];
     if (file) {
       this.inputFormControl.setValue(file.name);

--- a/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/file-editor/file-editor.ts
@@ -3,7 +3,6 @@ import { FormsModule, ReactiveFormsModule, UntypedFormControl, ValidatorFn, Vali
 import { Entry } from '../models/entry';
 import { EntryValueType } from '../models/entry-value-type';
 import { EntryValue } from '../models/entry-value';
-import { CommonModule } from '@angular/common';
 import { MatError, MatFormField, MatLabel, MatPrefix } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconButton } from '@angular/material/button';
@@ -11,7 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'entry-file-editor',
-  imports: [CommonModule, MatFormField, MatLabel, MatPrefix, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule],
+  imports: [MatFormField, MatLabel, MatPrefix, FormsModule, MatError, ReactiveFormsModule, MatInputModule, MatIconButton, MatIconModule],
   templateUrl: './file-editor.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './file-editor.scss',

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
@@ -1,41 +1,25 @@
 <!-- SLIDER -->
 @if (shouldUseSlider() && !useTextArea()) {
   <div class="slider-wrap">
-    <label class="slider-label">{{ entry().displayName }}</label>
+    <label class="slider-label" [class.entry-editor-disabled]="disabled()">{{ entry().displayName }}</label>
     <div class="slider-row">
-      <mat-slider
-        class="entry-slider"
-        [min]="entry().validation?.minimum"
-        [max]="entry().validation?.maximum"
-        [step]="getSliderStep()"
-        [discrete]="!shouldShowInlineInput()"
-        [disabled]="inputFormControl.disabled"
+      <mat-slider class="entry-slider" [min]="entry().validation?.minimum" [max]="entry().validation?.maximum"
+        [step]="getSliderStep()" [discrete]="!shouldShowInlineInput()" [disabled]="inputFormControl.disabled"
         [showTickMarks]="true">
-        <input
-          matSliderThumb
-          [ngModel]="
-          inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+        <input matSliderThumb
+          [ngModel]="inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
             ? entry().validation?.minimum ?? 0
-              : inputFormControl.value
-        "
+            : inputFormControl.value"
           (ngModelChange)="inputFormControl.setValue($event)" />
       </mat-slider>
       @if (shouldShowInlineInput()) {
         <mat-form-field class="slider-inline-input" appearance="outline" subscriptSizing="dynamic">
-          <input
-            matInput
-            type="number"
-            [step]="getSliderStep()"
-            [min]="entry().validation?.minimum!"
-            [max]="entry().validation?.maximum!"
-            [formControl]="inputFormControl"
-            inputmode="decimal"
+          <input matInput type="number" [step]="getSliderStep()" [min]="entry().validation?.minimum!"
+            [max]="entry().validation?.maximum!" [formControl]="inputFormControl" inputmode="decimal"
             [readonly]="readOnly()"
-            [placeholder]="
-          inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
-            ? entry().value.default ?? ''
-            : ''
-        " />
+            [placeholder]="inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+              ? entry().value.default ?? ''
+              : ''" />
         </mat-form-field>
       }
     </div>
@@ -45,26 +29,22 @@
     <mat-label>{{ entry().displayName }}</mat-label>
     @if (!useTextArea()) {
       <!--  ToDo: Cleanup placeholder -->
-      <input
-        aria-label="Text field for changing an entry value."
+      <input aria-label="Text field for changing an entry value."
         [type]="isPassword ? 'password' : isNumber ? 'number' : 'text'"
         [attr.min]="isNumber ? entry().validation?.minimum : null"
         [attr.max]="isNumber ? entry().validation?.maximum : null"
         [attr.step]="isNumber ? getSliderStep() : null"
         [attr.inputmode]="isNumber ? 'decimal' : null"
-        [placeholder]="
-        inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+        [placeholder]="inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
           ? entry().value.default ?? ''
-          : ''
-      "
-        [readonly]="readOnly()"
-        matInput
-        [formControl]="inputFormControl" />
+          : ''"
+        [readonly]="readOnly()" matInput [formControl]="inputFormControl" />
+    }
+    @if (entry().value.isReadOnly) {
+      <mat-icon matSuffix [class.entry-editor-disabled]="disabled()">lock</mat-icon>
     }
     @if (entry().description) {
-      <mat-hint
-        [ngClass]="{ 'entry-editor-disabled': disabled() || (entry().value.isReadOnly ?? false) }"
-        class="truncate">
+      <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
         {{ entry().description }}
       </mat-hint>
     }
@@ -95,29 +75,18 @@
     }
     <!-- TEXTAREA -->
     @if (useTextArea()) {
-      <textarea
-        matInput
-        [placeholder]="
-        inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
+      <textarea matInput
+        [placeholder]="inputFormControl.value === '' || inputFormControl.value === null || inputFormControl.value === undefined
           ? entry().value.default ?? ''
-          : ''
-      "
-        rows="5"
-        [formControl]="inputFormControl"></textarea>
+          : ''"
+        rows="5" [formControl]="inputFormControl"></textarea>
     }
     @if (!isPassword && !isNumber && !readOnly() && !useTextArea()) {
-      <button
-        mat-icon-button
-        type="button"
-        matSuffix
-        class="code-button"
-        [disabled]="inputFormControl.disabled"
-        [attr.aria-label]="'html editor'"
-        (click)="setTextArea(!useTextArea())"
-      >
+      <button mat-icon-button type="button" matSuffix class="code-button"
+        [disabled]="inputFormControl.disabled" [attr.aria-label]="'html editor'"
+        (click)="setTextArea(!useTextArea())">
         <mat-icon>code</mat-icon>
       </button>
     }
   </mat-form-field>
 }
-

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.html
@@ -44,7 +44,7 @@
       <mat-icon matSuffix [class.entry-editor-disabled]="disabled()">lock</mat-icon>
     }
     @if (entry().description) {
-      <mat-hint [ngClass]="{ 'entry-editor-disabled': disabled() }" class="truncate">
+      <mat-hint [class.entry-editor-disabled]="disabled()" class="truncate">
         {{ entry().description }}
       </mat-hint>
     }

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
@@ -35,12 +35,12 @@ import { MatSliderModule } from '@angular/material/slider';
   styleUrl: './input-editor.scss',
 })
 export class InputEditor implements OnDestroy {
-  inputFormControl!: UntypedFormControl;
+  protected inputFormControl!: UntypedFormControl;
   private formControlSubscription?: Subscription;
-  isPassword!: boolean;
-  isNumber!: boolean;
-  useTextArea = signal(false);
-  readOnly = signal<boolean>(false);
+  protected isPassword!: boolean;
+  protected isNumber!: boolean;
+  protected useTextArea = signal(false);
+  protected readOnly = signal<boolean>(false);
   disabled = input<boolean>(false);
   entry = model.required<Entry>();
   private readonly INLINE_INPUT_RANGE_THRESHOLD = 100;
@@ -106,17 +106,17 @@ export class InputEditor implements OnDestroy {
   }
 
   // ToDo: Check if anything like C# out variable for function exists and use here
-  isSinglePossibleValue(entry: Entry): boolean {
+  private isSinglePossibleValue(entry: Entry): boolean {
     const result = entry.value.possible && entry.value.possible.length === 1;
     return result ?? false;
   }
 
-  disableInputFormControl(control: UntypedFormControl, disable: boolean) {
+  private disableInputFormControl(control: UntypedFormControl, disable: boolean) {
     if (disable) control.disable();
     else control.enable();
   }
 
-  setupValidators(entry: Entry): ValidatorFn[] {
+  private setupValidators(entry: Entry): ValidatorFn[] {
     var validators = [] as ValidatorFn[];
     validators.push(invalidEntryValueValidator(entry.value.type));
     if (entry.validation?.isRequired) validators.push(Validators.required);
@@ -179,14 +179,14 @@ export class InputEditor implements OnDestroy {
     this.formControlSubscription?.unsubscribe();
   }
 
-  addTextValidators(validators: ValidatorFn[]) {
+  private addTextValidators(validators: ValidatorFn[]) {
     const regex = this.entry().validation?.regex;
     if (regex) {
       validators.push(Validators.pattern(regex));
     }
   }
 
-  addNumberValidators(validators: ValidatorFn[]) {
+  private addNumberValidators(validators: ValidatorFn[]) {
     var typeSpecificMaximum = this.getTypeSpecificMaximum(this.entry().value?.type);
     var typeSpecificMinimum = this.getTypeSpecificMinimum(this.entry().value?.type);
 
@@ -198,7 +198,7 @@ export class InputEditor implements OnDestroy {
     );
   }
 
-  getTypeSpecificMaximum(type: EntryValueType | undefined): number {
+  private getTypeSpecificMaximum(type: EntryValueType | undefined): number {
     switch (type) {
       case EntryValueType.Byte:
         return 255;
@@ -223,7 +223,7 @@ export class InputEditor implements OnDestroy {
     }
   }
 
-  getTypeSpecificMinimum(type: EntryValueType | undefined): number {
+  private getTypeSpecificMinimum(type: EntryValueType | undefined): number {
     switch (type) {
       case EntryValueType.Byte:
         return 0;
@@ -248,7 +248,7 @@ export class InputEditor implements OnDestroy {
     }
   }
 
-  determineInputType() {
+  private determineInputType() {
     if (
       EntryValueType.Int16 === this.entry().value?.type ||
       EntryValueType.UInt16 === this.entry().value?.type ||
@@ -264,11 +264,11 @@ export class InputEditor implements OnDestroy {
     else if (EntryUnitType.Password === this.entry().value?.unitType) this.isPassword = true;
   }
 
-  setTextArea(value: boolean) {
+  protected setTextArea(value: boolean) {
     this.useTextArea.set(value);
   }
 
-  shouldUseSlider(): boolean {
+  protected shouldUseSlider(): boolean {
     return this.defaultSliderCheck(this.entry());
   }
 
@@ -284,7 +284,7 @@ export class InputEditor implements OnDestroy {
     return min > typeMin || max < typeMax;
   }
 
-  getSliderStep(): number {
+  protected getSliderStep(): number {
     switch (this.entry().value.type) {
       case EntryValueType.Single:
       case EntryValueType.Double:
@@ -306,7 +306,7 @@ export class InputEditor implements OnDestroy {
     return Math.max(minAbs, maxAbs).toString().length;
   }
 
-  shouldShowInlineInput(): boolean {
+  protected shouldShowInlineInput(): boolean {
     return this.isNumber && (this.getRange() > this.INLINE_INPUT_RANGE_THRESHOLD || this.maxDigits() > 3);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/input-editor/input-editor.ts
@@ -10,7 +10,6 @@ import {
   minEntryValueValidator,
   parseCultureIndependentFloat
 } from '../validators/entry-editor.validators';
-import { CommonModule } from '@angular/common';
 import { MatError, MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
@@ -21,7 +20,6 @@ import { MatSliderModule } from '@angular/material/slider';
 @Component({
   selector: 'entry-input-editor',
   imports: [
-    CommonModule,
     FormsModule,
     MatError,
     MatLabel,

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.html
@@ -12,7 +12,7 @@
           }
         }
       </div>
-      @if (entryInfo.currentEntry()?.description; as description) {
+      @if (entryInfo.currentEntry().description; as description) {
         <p class="navigation-description">{{ description }}</p>
       }
     </div>

--- a/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
+++ b/projects/ngx-web-framework/entry-editor/navigable-entry-editor.ts
@@ -15,24 +15,27 @@ import { EntryEditor } from './entry-editor';
 export class NavigableEntryEditor implements OnDestroy {
   private service = inject(NavigableEntryService);
 
-  // ToDo: Add proper comments for public inputs
+  /** Optional query parameter name used to sync the navigation state with the URL. */
   queryParam = input<string | undefined>(undefined);
+
+  /** Whether the editor and all its sub-editors are disabled. */
   disabled = input.required<boolean>();
 
+  /** The root entry to display and edit. Changes are propagated back via two-way binding. */
   entry = model.required<Entry>();
 
   //id of the navigableEditor in order to be able to use several entry editors at the same time
-  editorId = computed(() => {
+  protected editorId = computed(() => {
     const queryParam = this.queryParam();
     return untracked(() => this.service.signIn(this.entry, queryParam));
   });
 
-  entryInformation = computed(() => {
+  protected entryInformation = computed(() => {
     const editorId = this.editorId();
     return untracked(() => this.service.entryEditorInformation.get(editorId));
   });
-    
-  onEntryChange(entry: Entry) {
+
+  protected onEntryChange(entry: Entry) {
     this.service.onEntryChange(this.editorId(), entry);
   }
 
@@ -40,7 +43,7 @@ export class NavigableEntryEditor implements OnDestroy {
     this.service.signOut(this.editorId());
   }
 
-  onNavigateSpecific(entry: WritableSignal<Entry>) {
+  protected onNavigateSpecific(entry: WritableSignal<Entry>) {
     this.service.onNavigateToSpecificEntry(this.editorId(), entry);
   }
 }

--- a/projects/ngx-web-framework/entry-editor/style/entry-editor-base.scss
+++ b/projects/ngx-web-framework/entry-editor/style/entry-editor-base.scss
@@ -2,36 +2,6 @@
   flex: 1;
 }
 
-.entry-editor-disabled {
-  color: rgba(0, 0, 0, 0.38);
-  cursor: default;
-}
-
-.entry-editor-list-item-button-icon {
-  font-size: 32px;
-}
-
-.entry-editor-add-list-item {
-  display: flex;
-  align-items: center;
-  margin: 0px 0px 1px 0px;
-  height: fit-content;
-  padding-top: 5px;
-}
-
-.entry-editor-add-list-item-type-selector {
-  flex: 1 1;
-  margin-right: 8px;
-}
-
-.entry-editor-add-list-item-button {
-  height: 38px;
-  width: 38px;
-  margin: 2px 4px 4px -2px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
 .truncate {
   width: auto;
   white-space: nowrap;
@@ -39,8 +9,14 @@
   text-overflow: ellipsis;
   height: 100%;
 }
-.entry-form-field{
+
+.entry-form-field {
   margin: 2px;
   display: flex;
   flex-direction: column;
+}
+
+.entry-editor-disabled {
+  color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
+  cursor: default;
 }

--- a/projects/ngx-web-framework/entry-editor/style/entry-editor-base.scss
+++ b/projects/ngx-web-framework/entry-editor/style/entry-editor-base.scss
@@ -20,3 +20,15 @@
   color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
   cursor: default;
 }
+
+.entry-hint {
+  display: block;
+  font: var(--mat-sys-body-small);
+  margin-top: 4px;
+  padding-left: 16px;
+  color: var(--mat-sys-on-surface-variant);
+
+  &.entry-editor-disabled {
+    color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
+  }
+}


### PR DESCRIPTION
- Reworked the whole disabling behavior of the entry editor
  - Controls get not disabled anymore when readonly (control still works eg. selecting text, but cannot be edited, style stays activated)
  - Implemented readonly in different components
  - Introduced lock-icon if readonly but editor is in edit-mode
  - Harmonized style of hints in all controls correctly 
- Reworked style end encapsulation of style in entry-editor
- Applied the same style guide requirements to ngx-moryx-web

<img width="1163" height="1074" alt="Screenshot 2026-07-16 at 16 16 18" src="https://github.com/user-attachments/assets/e29053f6-c51e-45ba-aa11-32b3dc9f66a4" />

<img width="525" height="285" alt="Screenshot 2026-07-16 at 16 16 57" src="https://github.com/user-attachments/assets/c6739b2e-0dea-447d-aca0-f09cf106d6f4" />

<img width="490" height="105" alt="Screenshot 2026-07-16 at 16 17 20" src="https://github.com/user-attachments/assets/be429a29-624f-4830-b7b1-445414aecf5d" />

<img width="504" height="192" alt="Screenshot 2026-07-16 at 16 17 30" src="https://github.com/user-attachments/assets/842d1d97-1522-4ddf-8330-50f38dc770a3" />

<img width="958" height="504" alt="Screenshot 2026-07-16 at 16 25 03" src="https://github.com/user-attachments/assets/35ebec14-6893-4d47-8323-ea1e55561675" />

