### PR TITLE
use EntryPossible as value since selection logic rely on `object` not `string`

### DIFF
--- a/projects/ngx-web-framework/entry-editor/entry-editor.html
+++ b/projects/ngx-web-framework/entry-editor/entry-editor.html
@@ -25,7 +25,7 @@
       <mat-select [disabled]="disabled() || (entry().value.isReadOnly ?? false)"
         [(ngModel)]="entry().value.current" (selectionChange)="dropdownSelectionChanged($event)">
         @for (pv of entry().value.possible; track pv.key) {
-          <mat-option [value]="pv.key">{{ pv.displayName ?? pv.key }}</mat-option>
+          <mat-option [value]="pv">{{ pv.displayName ?? pv.key }}</mat-option>
         }
       </mat-select>
       @if (entry().value.isReadOnly) {


### PR DESCRIPTION
Previously the value of a select-option was a string which was not what the selectionchange logic was expecting.

Now the EntryPossible value is used to match the selectionchange logic.

<img width="1922" height="741" alt="entry-prototype" src="https://github.com/user-attachments/assets/4d6b7564-84b1-4ba9-bf93-99dd1c083201" />

